### PR TITLE
Fix ghcLibPath in shake build

### DIFF
--- a/shake/Build.hs
+++ b/shake/Build.hs
@@ -197,7 +197,7 @@ main = shakeArgsWith shakeOptions{shakeFiles=rtsBuildDir} flags $ \flags targets
         let root x = rootDir </> x
         unit $ cmd "eta-pkg init " $ packageConfDir rootDir
         Stdout path <- cmd "stack eval GHC.Paths.libdir"
-        let ghcLibPath = drop 1 (init (init path))
+        let ghcLibPath = drop 1 $ init $ head $ lines path
             ghcInclude = ghcLibPath </> "include"
             etaInclude = etaIncludePath rootDir
         liftIO $ createDirectory etaInclude


### PR DESCRIPTION
(At least on my machine with FreeBSD 12-CURRENT, stack 1.2.0) `stack eval` returns the type of the expression on the second line, so I've been getting paths like these:

    /home/greg/.stack/programs/x86_64-freebsd/ghc-7.10.3/lib/ghc-7.10.3"
    it :: FilePat/include/ghcplatform.h