### PR TITLE
Add OS X Travis Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,42 @@ addons:
     packages:
       - libgmp-dev
 
+matrix:
+  include:
+    - env: CABALVER=1.22 GHCVER=7.10.3
+      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3],sources: [hvr-ghc]}}
+    - env: BUILD=stack ARGS="--resolver lts-6.7"
+      compiler: ": #stack 7.10.3 osx"
+      os: osx
+
 before_install:
+# Using compiler above sets CC to an invalid value, so unset it
+- unset CC
+
+# We want to always allow newer versions of packages when building on GHC HEAD
+- CABALARGS=""
+- if [ "x$GHCVER" = "xhead" ]; then CABALARGS=--allow-newer; fi
+
 # Download and unpack the stack executable
+- export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.local/bin:/opt/alex/$ALEXVER/bin:/opt/happy/$HAPPYVER/bin:$HOME/.cabal/bin:$PATH
 - mkdir -p ~/.local/bin
-- export PATH=$HOME/.local/bin:$PATH
-- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+- |
+  if [ `uname` = "Darwin" ]
+  then
+    travis_retry curl --insecure -L https://www.stackage.org/stack/osx-x86_64 | tar xz --strip-components=1 --include '*/stack' -C ~/.local/bin
+  else
+    travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  fi
+
+  # Use the more reliable S3 mirror of Hackage
+  mkdir -p $HOME/.cabal
+  echo 'remote-repo: hackage.haskell.org:http://hackage.fpcomplete.com/' > $HOME/.cabal/config
+  echo 'remote-repo-cache: $HOME/.cabal/packages' >> $HOME/.cabal/config
+
+  if [ "$CABALVER" != "1.16" ]
+  then
+    echo 'jobs: $ncpus' >> $HOME/.cabal/config
+  fi
 
 install:
 # Build dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,6 @@ cache:
   - $HOME/.cabal
   - $HOME/.stack
 
-# Ensure necessary system libraries are present
-addons:
-  apt:
-    packages:
-      - 
-
 matrix:
   include:
     - env: BUILD=stack ARGS="--resolver lts-6.6"
@@ -65,6 +59,9 @@ script:
 # Build the package, its tests, and its docs and run the tests
 - cd tests/verify/
 - ./verify.sh
-- cd ../packages/
-- ./Test.hs
-
+- |
+  if [ `uname` != "Darwin"]
+  then
+    cd ../packages/
+    ./Test.hs
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ cache:
 addons:
   apt:
     packages:
-      - libgmp-dev
+      - 
 
 matrix:
   include:
-    - env: CABALVER=1.22 GHCVER=7.10.3
-      addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.3],sources: [hvr-ghc]}}
-    - env: BUILD=stack ARGS="--resolver lts-6.7"
+    - env: BUILD=stack ARGS="--resolver lts-6.6"
+      addons: {apt: {packages: [libgmp-dev]}}
+      compiler: ": #stack 7.10.3 linux"
+    - env: BUILD=stack ARGS="--resolver lts-6.6"
       compiler: ": #stack 7.10.3 osx"
       os: osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 
 language: java
 
-jdk:
-  - oraclejdk8
-
 # Caching so the next build will be fast too.
 cache:
   directories:
@@ -22,10 +19,12 @@ addons:
 matrix:
   include:
     - env: BUILD=stack ARGS="--resolver lts-6.6"
-      addons: {apt: {packages: [libgmp-dev]}}
+      addons: {apt: {packages: [libgmp-dev, oracle-java8-installer]}}
+      os: linux
       compiler: ": #stack 7.10.3 linux"
     - env: BUILD=stack ARGS="--resolver lts-6.6"
       compiler: ": #stack 7.10.3 osx"
+      osx_image: xcode8
       os: osx
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ before_install:
 install:
 # Build dependencies
 - stack --no-terminal --install-ghc test --only-dependencies
-- travis_wait ./install.sh
+- travis_wait 30 ./install.sh
 
 script:
 # Build the package, its tests, and its docs and run the tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ script:
 - cd tests/verify/
 - ./verify.sh
 - |
-  if [ `uname` != "Darwin"]
+  if [ `uname` != "Darwin" ]
   then
     cd ../packages/
     ./Test.hs


### PR DESCRIPTION
Right now, OS X just runs till `verify.sh`. Only the Linux container, builds the entire package set.