### PR TITLE
Use touchFile on Windows as GHCs touchy is not available

### DIFF
--- a/compiler/ETA/Main/SysTools.hs
+++ b/compiler/ETA/Main/SysTools.hs
@@ -88,6 +88,7 @@ import qualified System.Posix.Internals
 #else /* Must be Win32 */
 import Foreign
 import Foreign.C.String
+import System.PosixCompat.Files
 #endif
 
 import System.Process
@@ -1038,7 +1039,11 @@ runWindres dflags args = do
 
 touch :: DynFlags -> String -> String -> IO ()
 touch dflags purpose arg =
+#ifndef mingw32_HOST_OS
   runSomething dflags purpose (pgm_T dflags) [FileOption "" arg]
+#else
+  touchFile arg
+#endif
 
 copy :: DynFlags -> String -> FilePath -> FilePath -> IO ()
 copy dflags purpose from to = copyWithHeader dflags purpose Nothing from to

--- a/eta.cabal
+++ b/eta.cabal
@@ -316,6 +316,7 @@ library
 
     if os(windows)
         build-depends:   Win32
+                       , unix-compat
     else
         build-depends:   unix
     hs-source-dirs:      compiler


### PR DESCRIPTION
As `eta` doesn't supply a `touchy` equivalent as GHC does. This path sidesteps the issue by doing the `touch` *in* `eta`. This is a very unclean solution. If the user supplies a custom path to `touch` or `touchy` with `-pgm_T` the path gets ignored on Windows. 