### PR TITLE
Use portable `touchFile` implementation in `touchObjectFile`

### DIFF
--- a/compiler/ETA/Main/DriverPipeline.hs
+++ b/compiler/ETA/Main/DriverPipeline.hs
@@ -82,6 +82,7 @@ import Data.IORef       ( readIORef )
 import System.Directory
 import System.FilePath
 import System.IO
+import System.PosixCompat.Files (fileExist, touchFile)
 import Control.Monad hiding (void)
 import Data.Foldable    (fold)
 import Data.List        ( isSuffixOf, partition, nub )
@@ -1713,7 +1714,10 @@ hscPostBackendPhase dflags _ hsc_lang =
 touchObjectFile :: DynFlags -> FilePath -> IO ()
 touchObjectFile dflags path = do
   createDirectoryIfMissing True $ takeDirectory path
-  SysTools.touch dflags "Touching object file" path
+  exists <- fileExist path
+  if exists
+    then touchFile path
+    else writeFile path ""
 
 haveRtsOptsFlags :: DynFlags -> Bool
 haveRtsOptsFlags dflags =

--- a/compiler/ETA/Main/DynFlags.hs
+++ b/compiler/ETA/Main/DynFlags.hs
@@ -66,7 +66,7 @@ module ETA.Main.DynFlags (
         ghcUsagePath, ghciUsagePath, topDir, tmpDir, rawSettings,
         versionedAppDir,
         extraGccViaCFlags, systemPackageConfig,
-        pgm_L, pgm_P, pgm_F, pgm_c, pgm_s, pgm_a, pgm_l, pgm_dll, pgm_T,
+        pgm_L, pgm_P, pgm_F, pgm_c, pgm_s, pgm_a, pgm_l, pgm_dll,
         pgm_sysman, pgm_windres, pgm_libtool, pgm_readelf, pgm_lo, pgm_lc,
         pgm_javac,
         opt_L, opt_P, opt_F, opt_c, opt_a, opt_l,
@@ -930,7 +930,6 @@ data Settings = Settings {
   sPgm_a                 :: (String,[Option]),
   sPgm_l                 :: (String,[Option]),
   sPgm_dll               :: (String,[Option]),
-  sPgm_T                 :: String,
   sPgm_sysman            :: String,
   sPgm_windres           :: String,
   sPgm_libtool           :: String,
@@ -987,8 +986,6 @@ pgm_l                 :: DynFlags -> (String,[Option])
 pgm_l dflags = sPgm_l (settings dflags)
 pgm_dll               :: DynFlags -> (String,[Option])
 pgm_dll dflags = sPgm_dll (settings dflags)
-pgm_T                 :: DynFlags -> String
-pgm_T dflags = sPgm_T (settings dflags)
 pgm_sysman            :: DynFlags -> String
 pgm_sysman dflags = sPgm_sysman (settings dflags)
 pgm_windres           :: DynFlags -> String

--- a/compiler/ETA/Main/SysTools.hs
+++ b/compiler/ETA/Main/SysTools.hs
@@ -35,7 +35,6 @@ module ETA.Main.SysTools (
 
         askCc,
 
-        touch,                  -- String -> String -> IO ()
         copy,
         copyWithHeader,
 
@@ -270,8 +269,6 @@ initSysTools mbMinusB
 
        tmpdir <- getTemporaryDirectory
 
-       touch_path <- getSetting "touch command"
-
        let -- On Win32 we don't want to rely on #!/bin/perl, so we prepend
            -- a call to Perl to get the invocation of split.
            -- On Unix, scripts are invoked using the '#!' method.  Binary
@@ -334,7 +331,6 @@ initSysTools mbMinusB
                     sPgm_a   = (as_prog, as_args),
                     sPgm_l   = (ld_prog, ld_args),
                     sPgm_dll = (mkdll_prog,mkdll_args),
-                    sPgm_T   = touch_path,
                     sPgm_sysman  = top_dir ++ "/ghc/rts/parallel/SysMan",
                     sPgm_windres = windres_path,
                     sPgm_libtool = libtool_path,
@@ -1035,10 +1031,6 @@ runWindres dflags args = do
             : args
   mb_env <- getGccEnv gcc_args
   runSomethingFiltered dflags id "Windres" windres args' mb_env
-
-touch :: DynFlags -> String -> String -> IO ()
-touch dflags purpose arg =
-  runSomething dflags purpose (pgm_T dflags) [FileOption "" arg]
 
 copy :: DynFlags -> String -> FilePath -> FilePath -> IO ()
 copy dflags purpose from to = copyWithHeader dflags purpose Nothing from to

--- a/eta.cabal
+++ b/eta.cabal
@@ -313,6 +313,7 @@ library
                        , array
                        , containers
                        , cpphs
+                       , unix-compat
 
     if os(windows)
         build-depends:   Win32


### PR DESCRIPTION
This is the patch discussed in https://github.com/typelead/eta/pull/141. This fixes https://github.com/typelead/eta/issues/142.