### PR TITLE
Fix eta-pkg list command

### DIFF
--- a/utils/eta-pkg/Main.hs
+++ b/utils/eta-pkg/Main.hs
@@ -682,7 +682,13 @@ getPkgDatabases verbosity modify use_user use_cache expand_vars my_flags = do
     infoLn ("modifying: " ++ show to_modify)
     infoLn ("flag db stack: " ++ show (map location flag_db_stack))
 
-  return (db_stack, to_modify, flag_db_stack)
+  return (db_stack, to_modify, (etaPkgDB flag_db_stack))
+    where
+      -- Right now Eta has both the global and the user package
+      -- databases as the same. So we just pass a single element from
+      -- the PackageDBStack for the list command.
+      etaPkgDB [] = []
+      etaPkgDB (x:_) = [x]
 
 
 lookForPackageDBIn :: FilePath -> IO (Maybe FilePath)


### PR DESCRIPTION
Right now it fixes the `eta-pkg list` command which annoys me to a
bigger extent that I expected. The old ouput of `eta-pkg list` was
this:

``` shellsession
sibi::jane { ~ }-> eta-pkg list
/home/sibi/.eta/package.conf.d
   array-0.5.1.1
   base-4.8.2.0
   ghc-boot-th-8.0.1
   ghc-prim-0.4.0.0
   integer-0.5.1.0
   rts-0.1.0.0
/home/sibi/.eta/package.conf.d
   array-0.5.1.1
   base-4.8.2.0
   ghc-boot-th-8.0.1
   ghc-prim-0.4.0.0
   integer-0.5.1.0
   rts-0.1.0.0
/home/sibi/.eta/package.conf.d
   array-0.5.1.1
   base-4.8.2.0
   ghc-boot-th-8.0.1
   ghc-prim-0.4.0.0
   integer-0.5.1.0
   rts-0.1.0.0
/home/sibi/.eta/package.conf.d
   array-0.5.1.1
   base-4.8.2.0
   ghc-boot-th-8.0.1
   ghc-prim-0.4.0.0
   integer-0.5.1.0
   rts-0.1.0.0
```

Now, it gives up this:

``` shellsession
@sibi::jane { ~ }-> eta-pkg list
/home/sibi/.eta/package.conf.d
   array-0.5.1.1
   base-4.8.2.0
   ghc-prim-0.4.0.0
   integer-0.5.1.0
   rts-0.1.0.0
```

Note that I can fix this more cleanly - I can remove trying to query
user database and so on. But I'm doing it this way as I feel in future we
may have a separate user package db for Eta. This also fixes #75.