### PR TITLE
Fix minor typo in the Getting Started page

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -386,7 +386,7 @@ Consider the following Java code:
        return counter;
      }
 
-     public int set(int value) {
+     public void set(int value) {
        this.counter = Math.min(value, COUNTER_MAX);
        this.publicCounter = counter;
      }


### PR DESCRIPTION
For the ```Counter``` class example, ```public int set``` should be ```public void set```.  This matches the imported type signature:

    foreign import java unsafe set :: Int -> Java Counter ()