### PR TITLE
Problematic code didn't have Serializable

### DIFF
--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -933,7 +933,7 @@ The problematic code above can now be fixed::
   data {-# CLASS "java.io.File" #-} File = File (Object# File)
     deriving Class
 
-  type instance Inherits File = '[Object, Serializable]
+  type instance Inherits File = '[Object]
 
   main :: IO ()
   main = do
@@ -950,7 +950,7 @@ We can even change the code above to use the `Java` monad::
   data {-# CLASS "java.io.File" #-} File = File (Object# File)
     deriving Class
 
-  type instance Inherits File = '[Object, Serializable]
+  type instance Inherits File = '[Object]
 
   main :: IO ()
   main = do


### PR DESCRIPTION
Since the problematic code didn't have Serializable, I think it would be
better to remove it from here also. Initially observing the code, I
thought the fix had something to do with Serializable object.