### PR TITLE
Adds missing array exports array(To/From)List

### DIFF
--- a/libraries/base/Java/Array.hs
+++ b/libraries/base/Java/Array.hs
@@ -28,7 +28,9 @@ module Java.Array
     JStringArray(..),
     JObjectArray(..),
     JArray(..),
-    alength
+    alength,
+    arrayToList,
+    arrayFromList
   )
 where
 


### PR DESCRIPTION
Noticed that the `arrayToList` and `arrayFromList` in the documentation http://eta-lang.org/docs/html/getting-started.html#working-with-arrays were not exported (unsure if on purpose and I'm missing something obvious), this fixed the problem for me