### PR TITLE
Implements memmove, memcpy and memset for Foreign.Marshal

### DIFF
--- a/libraries/base/Foreign/Marshal/Utils.hs
+++ b/libraries/base/Foreign/Marshal/Utils.hs
@@ -180,15 +180,22 @@ fillBytes dest char size = do
 -- auxilliary routines
 -- -------------------
 
--- TODO: Implement!
 -- |Basic C routines needed for memory copying
 --
--- foreign import ccall unsafe "string.h"
+foreign import java unsafe "@static eta.base.Utils.c_memcpy" c_memcpy
+  :: Ptr a -> Ptr a -> CSize -> IO (Ptr a)
+
 memcpy  :: Ptr a -> Ptr a -> CSize -> IO (Ptr a)
-memcpy = undefined
--- foreign import ccall unsafe "string.h"
+memcpy p q s = c_memcpy p q (fromIntegral s)
+
+foreign import java unsafe "@static eta.base.Utils.c_memmove" c_memmove
+  :: Ptr a -> Ptr a -> CSize -> IO (Ptr a)
+
 memmove :: Ptr a -> Ptr a -> CSize -> IO (Ptr a)
-memmove = undefined
--- foreign import ccall unsafe "string.h"
-memset  :: Ptr a -> CInt  -> CSize -> IO (Ptr a)
-memset = undefined
+memmove p q s = c_memmove p q (fromIntegral s)
+
+foreign import java unsafe "@static eta.base.Utils.c_memset" c_memset
+  :: Ptr a -> CInt -> CSize -> IO (Ptr a)
+
+memset :: Ptr a -> CInt  -> CSize -> IO (Ptr a)
+memset p w s = c_memset p (fromIntegral w) s

--- a/libraries/base/java-utils/Utils.java
+++ b/libraries/base/java-utils/Utils.java
@@ -18,6 +18,7 @@ import eta.runtime.Rts;
 import eta.runtime.RtsFlags;
 import static eta.runtime.Rts.ExitCode;
 import eta.runtime.RtsMessages;
+import eta.runtime.io.MemoryManager;
 
 import java.lang.management.ManagementFactory;
 import com.sun.management.OperatingSystemMXBean;
@@ -121,6 +122,34 @@ public class Utils {
         byte[] bytes = new byte[buffer.remaining()];
         buffer.get(bytes);
         return new String(bytes, "UTF-8");
+    }
+
+    public static ByteBuffer c_memcpy(ByteBuffer dest, ByteBuffer src, int size) {
+        ByteBuffer src2 = src.duplicate();
+        ByteBuffer dest2 = dest.duplicate();
+        MemoryManager.bufSetLimit(src2, size);
+        dest2.put(src2);
+        return dest;
+    }
+
+    public static ByteBuffer c_memset(ByteBuffer b, int c_, int size) {
+        byte c = (byte) c_;
+        ByteBuffer b2 = b.duplicate();
+        while (size-- != 0) {
+            b2.put(c);
+        }
+        return b;
+    }
+
+    public static ByteBuffer c_memmove(ByteBuffer dest, ByteBuffer src, int size) {
+        ByteBuffer src2 = src.duplicate();
+        ByteBuffer dest2 = dest.duplicate();
+        ByteBuffer copy = ByteBuffer.allocate(size);
+        MemoryManager.bufSetLimit(src2, size);
+        copy.put(src2);
+        copy.flip();
+        dest2.put(copy);
+        return dest;
     }
 
     public static void printBuffer(ByteBuffer buffer) {


### PR DESCRIPTION
Fixes the `Prelude.undefined` panic in #221, 

Haven't dealt with ByteBuffers before but its almost
a verbatim copy of the implementation in the bytestring patch https://github.com/typelead/eta-hackage/blob/master/patches/bytestring-0.10.8.1.patch 

Since we already dup the src and copy its my understanding its safe to use the same method for both memcpy and memmove there's just no performance gain with memcpy