### PR TITLE
Print warning on .hsc files.

### DIFF
--- a/compiler/ETA/Main/DriverPipeline.hs
+++ b/compiler/ETA/Main/DriverPipeline.hs
@@ -1283,14 +1283,6 @@ findHSLib dflags dirs lib = do
       (x:_) -> Just x
   where file = lib <.> "jar"
   
-warnHscFile :: String -> IO ()
-warnHscFile h = putStrLn $ "WARN: File " ++ h ++ " of unsupported type (.hsc)"
-
-handleHscFiles :: [String] -> IO ()
-handleHscFiles hs = do
-  mapM_ warnHscFile hs
-  when (length hs > 0) $ panic "Found unsupported files (.hsc). Exiting."
-
 linkGeneric :: DynFlags -> [String] -> [PackageKey] -> IO ()
 linkGeneric dflags oFiles depPackages = do
     -- TODO: Figure out the right place for this error message
@@ -1301,7 +1293,6 @@ linkGeneric dflags oFiles depPackages = do
     --        (text $ "    Call hsInit() from your main() method to set"
     --          ++ " these options."))
     -- TODO: Use conduits to combine the jars
-    handleHscFiles $ filter (".hsc" `isSuffixOf`) (oFiles ++ (jarInputs dflags))
     mainFiles' <- maybeMainAndManifest dflags isExecutable
     mainFiles <- forM mainFiles' $ \(a, b) -> do
                    a' <- mkPath a

--- a/compiler/ETA/Main/DriverPipeline.hs
+++ b/compiler/ETA/Main/DriverPipeline.hs
@@ -1282,7 +1282,7 @@ findHSLib dflags dirs lib = do
       [] -> Nothing
       (x:_) -> Just x
   where file = lib <.> "jar"
-  
+
 linkGeneric :: DynFlags -> [String] -> [PackageKey] -> IO ()
 linkGeneric dflags oFiles depPackages = do
     -- TODO: Figure out the right place for this error message

--- a/compiler/ETA/Main/DriverPipeline.hs
+++ b/compiler/ETA/Main/DriverPipeline.hs
@@ -1282,6 +1282,9 @@ findHSLib dflags dirs lib = do
       [] -> Nothing
       (x:_) -> Just x
   where file = lib <.> "jar"
+  
+warnHscFile :: String -> IO ()
+warnHscFile h = putStrLn $ "WARN: File " ++ h ++ " of unsupported type (.hsc)"
 
 linkGeneric :: DynFlags -> [String] -> [PackageKey] -> IO ()
 linkGeneric dflags oFiles depPackages = do
@@ -1293,6 +1296,7 @@ linkGeneric dflags oFiles depPackages = do
     --        (text $ "    Call hsInit() from your main() method to set"
     --          ++ " these options."))
     -- TODO: Use conduits to combine the jars
+    mapM_ warnHscFile $ filter (".hsc" `isSuffixOf`) oFiles
     mainFiles' <- maybeMainAndManifest dflags isExecutable
     mainFiles <- forM mainFiles' $ \(a, b) -> do
                    a' <- mkPath a
@@ -1305,6 +1309,7 @@ linkGeneric dflags oFiles depPackages = do
             -- TODO: Verify that the right version eta was used
             --       in the Manifests of the jars being compiled
           else return []
+    mapM_ warnHscFile $ filter (".hsc" `isSuffixOf`) (jarInputs dflags)
     inputJars <- mapM getNonManifestEntries (jarInputs dflags)
     start <- getCurrentTime
     mergeClassesAndJars outputFn (compressionMethod dflags) mainFiles $

--- a/eta/Main.hs
+++ b/eta/Main.hs
@@ -603,9 +603,21 @@ addFlag s flag = liftEwM $ do
 -- ----------------------------------------------------------------------------
 -- Run --make mode
 
+warnHscFile :: String -> IO ()
+warnHscFile f = putStrLn $ "ERROR: File " ++ f ++ " of unsupported type (.hsc)"
+
+handleHscFiles :: [String] -> Ghc ()
+handleHscFiles fs =
+  if null fs
+  then return ()
+  else do
+    liftIO $ mapM_ warnHscFile fs
+    liftIO $ exitWith (ExitFailure 1)
+
 doMake :: [(String,Maybe Phase)] -> Ghc ()
 doMake srcs  = do
   hsc_env <- GHC.getSession
+  handleHscFiles $ filter (".hsc" `isSuffixOf`) (map fst srcs)
   if null hs_srcs
   then liftIO (oneShot hsc_env StopLn srcs)
   else do


### PR DESCRIPTION
Print out a warning if user passes in a `.hsc` file to the compiler. See issue https://github.com/typelead/eta/issues/97.

Should I add tests?

## Before

A `.hsc` file only.

```
€ eta Main.hsc
eta: panic! (the 'impossible' happened)
  (Eta version 0.0.5):
	Parsing of archive structure failed:
Cannot locate end of central directory
in "/home/vagrant/src/eta-paavo/hsc-test/Main.hsc"

Please report this as a Eta bug: http://github.org/typelead/eta/issues
```

Both `.hsc` and `.hs` files.

```
€ eta Main.hsc Main.hs
[1 of 1] Compiling Main             ( Main.hs, Main.jar )
Linking RunMain.jar ...
eta: panic! (the 'impossible' happened)
  (Eta version 0.0.5):
	Parsing of archive structure failed:
Cannot locate end of central directory
in "/home/vagrant/src/eta-paavo/hsc-test/Main.hsc"

Please report this as a Eta bug: http://github.org/typelead/eta/issues
```

## After

A `.hsc` file only.

```
€ eta Main.hsc
WARN: File Main.hsc of unsupported type (.hsc)
eta: panic! (the 'impossible' happened)
  (Eta version 0.0.5):
	Parsing of archive structure failed:
Cannot locate end of central directory
in "/home/vagrant/src/eta-paavo/hsc-test/Main.hsc"

Please report this as a Eta bug: http://github.org/typelead/eta/issues
```

Both `.hsc` and `.hs` files.

```
€ eta Main.hsc Main.hs
[1 of 1] Compiling Main             ( Main.hs, Main.jar )
Linking RunMain.jar ...
WARN: File Main.hsc of unsupported type (.hsc)
eta: panic! (the 'impossible' happened)
  (Eta version 0.0.5):
	Parsing of archive structure failed:
Cannot locate end of central directory
in "/home/vagrant/src/eta-paavo/hsc-test/Main.hsc"

Please report this as a Eta bug: http://github.org/typelead/eta/issues
```

