### PR TITLE
Use POSIX string equality operator

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,7 @@
 _pull=$(git pull)
 _subs=$(git submodule update --recursive)
 
-if [ "$_pull" == "Already up-to-date." ] && [ -z "$_subs" ]; then
+if [ "$_pull" = "Already up-to-date." ] && [ -z "$_subs" ]; then
 	echo "Already up-to-date."
 	exit 0
 fi


### PR DESCRIPTION
shebang is looking for sh but is using bash's `==` operator to compare strings.

According to http://pubs.opengroup.org/onlinepubs/9699919799/utilities/test.html correct operator is `=`.