### PR TITLE
Add Nix expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ utils/trace/Filter
 utils/trace/TRACE_DUMP
 node_modules/
 *.egg-info
+result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,79 @@
+with import <nixpkgs> { };
+
+# To get a shell with all of Eta's dependencies:
+#   $ nix-shell -A eta-build-shell
+#   [nix-shell] $ eta-build uninstall
+#   [nix-shell] $ eta-build install
+
+let
+  # Eta's Cabal can't be built with itself. Stack (incorrectly) caches a Simple
+  # Setup so it accidentally works around this problem. Here we build a Setup so
+  # that we can (incorrectly) reuse it, like Stack does.
+  Setup = stdenv.mkDerivation {
+    name = "eta-setup-hack";
+    phases = ["buildPhase" "installPhase"];
+    buildInputs = [hpkgs.ghc];
+    buildPhase = ''
+      ghc --make -o Setup ${./Setup.hs}
+    '';
+    installPhase = ''
+      mv Setup $out
+    '';
+  };
+
+  Cabal = self: haskell.lib.overrideCabal (self.callPackage ./utils/nix/Cabal.nix { }) (drv: {
+    postCompileBuildDriver = ''
+      rm Setup
+      ln -s ${Setup} Setup
+    '';
+    doCheck = false;
+  });
+
+  hpkgs = haskell.packages.ghc7103.override {
+    overrides = self: super: {
+      tasty-ant-xml = haskell.lib.doJailbreak super.tasty-ant-xml;
+
+      epm = haskell.lib.overrideCabal (self.callPackage ./utils/nix/epm.nix {
+        Cabal = Cabal self;
+      }) (drv: {
+        postCompileBuildDriver = ''
+          rm Setup
+          ln -s ${Setup} Setup
+        '';
+        doCheck = false;
+      });
+      eta-pkg = haskell.lib.doJailbreak (self.callPackage ./utils/nix/eta-pkg.nix { });
+      eta-pkgdb = self.callPackage ./utils/nix/eta-pkgdb.nix { };
+      codec-jvm = self.callPackage ./utils/nix/codec-jvm.nix { };
+
+      eta-build = self.callPackage ./utils/nix/eta-build.nix { };
+
+      eta = haskell.lib.overrideCabal (self.callPackage ./utils/nix/eta.nix { }) (drv: {
+        src = onlyFiles ["compiler" "include" "eta" "eta.cabal" "LICENSE"] drv.src;
+        isLibrary = false;
+        doCheck = false;
+        jailbreak = true;
+      });
+    };
+  };
+
+  eta-build-shell = runCommand "eta-build-shell" {
+    # Libraries don't pass -encoding to javac.
+    LC_ALL = "en_US.utf8";
+    buildInputs = [
+      hpkgs.eta
+      hpkgs.eta-build
+      hpkgs.eta-pkg
+      hpkgs.epm
+      gitMinimal
+      jdk
+      glibcLocales
+    ];
+  } "";
+
+  rootName = name: builtins.elemAt (lib.splitString "/" name) 0;
+  isValidFile = name: files: builtins.elem (rootName name) files;
+  relative = path: name: lib.removePrefix (toString path + "/") name;
+  onlyFiles = files: path: builtins.filterSource (name: type: isValidFile (relative path name) files) path;
+in
+hpkgs // { Cabal = Cabal hpkgs; inherit eta-build-shell; }

--- a/utils/nix/Cabal.nix
+++ b/utils/nix/Cabal.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, array, base, binary, bytestring, containers
+, deepseq, directory, extensible-exceptions, filepath, HUnit
+, old-time, pretty, process, QuickCheck, regex-posix, stdenv
+, test-framework, test-framework-hunit, test-framework-quickcheck2
+, time, unix
+}:
+mkDerivation {
+  pname = "Cabal";
+  version = "1.22.8.0";
+  src = ../../epm/Cabal;
+  libraryHaskellDepends = [
+    array base binary bytestring containers deepseq directory filepath
+    pretty process time unix
+  ];
+  testHaskellDepends = [
+    base bytestring containers directory extensible-exceptions filepath
+    HUnit old-time process QuickCheck regex-posix test-framework
+    test-framework-hunit test-framework-quickcheck2 unix
+  ];
+  homepage = "http://www.haskell.org/cabal/";
+  description = "A framework for packaging Haskell software";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/utils/nix/codec-jvm.nix
+++ b/utils/nix/codec-jvm.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, array, base, binary, bytestring, containers, mtl
+, stdenv, text
+}:
+mkDerivation {
+  pname = "codec-jvm";
+  version = "0.1";
+  src = ../../codec-jvm;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    array base binary bytestring containers mtl text
+  ];
+  executableHaskellDepends = [ base bytestring text ];
+  license = stdenv.lib.licenses.asl20;
+}

--- a/utils/nix/epm.nix
+++ b/utils/nix/epm.nix
@@ -1,0 +1,25 @@
+{ mkDerivation, array, base, bytestring, Cabal, containers
+, directory, extensible-exceptions, filepath, HTTP, HUnit, mtl
+, network, network-uri, pretty, process, QuickCheck, random
+, regex-posix, stdenv, stm, test-framework, test-framework-hunit
+, test-framework-quickcheck2, time, unix, zlib
+}:
+mkDerivation {
+  pname = "epm";
+  version = "0.0.1";
+  src = ../../epm/epm;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    array base bytestring Cabal containers directory filepath HTTP mtl
+    network network-uri pretty process random stm time unix zlib
+  ];
+  testHaskellDepends = [
+    array base bytestring Cabal containers directory
+    extensible-exceptions filepath HTTP HUnit mtl network network-uri
+    pretty process QuickCheck regex-posix stm test-framework
+    test-framework-hunit test-framework-quickcheck2 time unix zlib
+  ];
+  description = "The command-line interface for the ETA Package Manager";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/utils/nix/eta-build.nix
+++ b/utils/nix/eta-build.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, Cabal, containers, directory, shake, stdenv
+}:
+mkDerivation {
+  pname = "eta-build";
+  version = "0.0.5";
+  src = ../../shake;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    base Cabal containers directory shake
+  ];
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/utils/nix/eta-pkg.nix
+++ b/utils/nix/eta-pkg.nix
@@ -1,0 +1,16 @@
+{ mkDerivation, base, binary, bytestring, Cabal, containers
+, directory, eta-pkgdb, filepath, process, stdenv, terminfo, unix
+}:
+mkDerivation {
+  pname = "eta-pkg";
+  version = "0.0.5";
+  src = ../eta-pkg;
+  isLibrary = false;
+  isExecutable = true;
+  executableHaskellDepends = [
+    base binary bytestring Cabal containers directory eta-pkgdb
+    filepath process terminfo unix
+  ];
+  description = "XXX";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/utils/nix/eta-pkgdb.nix
+++ b/utils/nix/eta-pkgdb.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, binary, bytestring, directory, filepath
+, stdenv
+}:
+mkDerivation {
+  pname = "eta-pkgdb";
+  version = "0.0.0.0";
+  src = ../eta-pkgdb;
+  libraryHaskellDepends = [
+    base binary bytestring directory filepath
+  ];
+  description = "The GHC compiler's view of the GHC package database format";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/utils/nix/eta.nix
+++ b/utils/nix/eta.nix
@@ -1,0 +1,26 @@
+{ mkDerivation, aeson, alex, array, base, bytestring, codec-jvm
+, containers, cpphs, deepseq, directory, eta-pkgdb, exceptions
+, filepath, happy, haskeline, hpc, mtl, path, path-io, process
+, stdenv, text, time, transformers, turtle, unix, unix-compat, zip
+}:
+mkDerivation {
+  pname = "eta";
+  version = "0.0.5";
+  src = ../..;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    array base bytestring codec-jvm containers cpphs directory
+    eta-pkgdb exceptions filepath hpc mtl path path-io process text
+    time transformers unix unix-compat zip
+  ];
+  libraryToolDepends = [ alex happy ];
+  executableHaskellDepends = [
+    array base bytestring deepseq directory filepath haskeline process
+    transformers unix
+  ];
+  testHaskellDepends = [
+    aeson base bytestring directory filepath text turtle
+  ];
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
This includes expressions generated via cabal2nix for each of the needed Cabal
projects. Some workarounds were needed to make building similar to Stack.

There's a shell which can be entered to run the "eta-build" command to init epm
and the base Eta packages:

    $ nix-shell -A eta-build-shell