### PR TITLE
Change translation of __NULL literal in bytecode generation phase

### DIFF
--- a/compiler/ETA/CodeGen/Rts.hs
+++ b/compiler/ETA/CodeGen/Rts.hs
@@ -293,3 +293,6 @@ debugPrint ft = dup ft
   where genFt (ObjectType _) = jobject
         genFt (ArrayType _)  = jobject
         genFt ft             = ft
+
+nullAddr :: Code
+nullAddr = getstatic $ mkFieldRef memoryManager "nullAddress" byteBufferType

--- a/compiler/ETA/CodeGen/Utils.hs
+++ b/compiler/ETA/CodeGen/Utils.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
 module ETA.CodeGen.Utils where
 
 import ETA.Main.DynFlags
@@ -27,8 +26,6 @@ cgLit (MachFloat r)         = (jfloat, fconst $ fromRational r)
 cgLit (MachDouble r)        = (jdouble, dconst $ fromRational r)
 -- TODO: Remove this literal variant?
 cgLit MachNullAddr          = (jobject, nullAddr)
-  where nullAddr = getstatic $ mkFieldRef memoryManager "nullAddress"
-                               byteBufferType
 cgLit (MachStr s)           = (jstring, sconst $ decodeUtf8 s)
 -- TODO: Implement MachLabel
 cgLit MachLabel {}          = error "cgLit: MachLabel"

--- a/compiler/ETA/CodeGen/Utils.hs
+++ b/compiler/ETA/CodeGen/Utils.hs
@@ -10,6 +10,7 @@ import Codec.JVM
 import Data.Char (ord)
 import Control.Arrow(first)
 import ETA.CodeGen.Name
+import ETA.CodeGen.Rts
 import ETA.Debug
 -- import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
@@ -26,8 +27,8 @@ cgLit (MachFloat r)         = (jfloat, fconst $ fromRational r)
 cgLit (MachDouble r)        = (jdouble, dconst $ fromRational r)
 -- TODO: Remove this literal variant?
 cgLit MachNullAddr          = (jobject, nullAddr)
-  where nullAddr = getstatic $ mkFieldRef "eta/runtime/io/MemoryManager"
-                   "nullAddress" (obj "java/nio/ByteBuffer")
+  where nullAddr = getstatic $ mkFieldRef memoryManager "nullAddress"
+                               (obj byteBuffer)
 cgLit (MachStr s)           = (jstring, sconst $ decodeUtf8 s)
 -- TODO: Implement MachLabel
 cgLit MachLabel {}          = error "cgLit: MachLabel"

--- a/compiler/ETA/CodeGen/Utils.hs
+++ b/compiler/ETA/CodeGen/Utils.hs
@@ -28,7 +28,7 @@ cgLit (MachDouble r)        = (jdouble, dconst $ fromRational r)
 -- TODO: Remove this literal variant?
 cgLit MachNullAddr          = (jobject, nullAddr)
   where nullAddr = getstatic $ mkFieldRef memoryManager "nullAddress"
-                               (obj byteBuffer)
+                               byteBufferType
 cgLit (MachStr s)           = (jstring, sconst $ decodeUtf8 s)
 -- TODO: Implement MachLabel
 cgLit MachLabel {}          = error "cgLit: MachLabel"

--- a/compiler/ETA/CodeGen/Utils.hs
+++ b/compiler/ETA/CodeGen/Utils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 module ETA.CodeGen.Utils where
 
 import ETA.Main.DynFlags
@@ -24,7 +25,9 @@ cgLit (MachWord64 i)        = (jlong, lconst $ fromIntegral i)
 cgLit (MachFloat r)         = (jfloat, fconst $ fromRational r)
 cgLit (MachDouble r)        = (jdouble, dconst $ fromRational r)
 -- TODO: Remove this literal variant?
-cgLit MachNullAddr          = (jobject, aconst_null jobject)
+cgLit MachNullAddr          = (jobject, nullAddr)
+  where nullAddr = getfield $ mkFieldRef "eta/runtime/io/MemoryManager"
+                   "nullAddress" (obj "java/nio/ByteBuffer")
 cgLit (MachStr s)           = (jstring, sconst $ decodeUtf8 s)
 -- TODO: Implement MachLabel
 cgLit MachLabel {}          = error "cgLit: MachLabel"

--- a/compiler/ETA/CodeGen/Utils.hs
+++ b/compiler/ETA/CodeGen/Utils.hs
@@ -26,7 +26,7 @@ cgLit (MachFloat r)         = (jfloat, fconst $ fromRational r)
 cgLit (MachDouble r)        = (jdouble, dconst $ fromRational r)
 -- TODO: Remove this literal variant?
 cgLit MachNullAddr          = (jobject, nullAddr)
-  where nullAddr = getfield $ mkFieldRef "eta/runtime/io/MemoryManager"
+  where nullAddr = getstatic $ mkFieldRef "eta/runtime/io/MemoryManager"
                    "nullAddress" (obj "java/nio/ByteBuffer")
 cgLit (MachStr s)           = (jstring, sconst $ decodeUtf8 s)
 -- TODO: Implement MachLabel

--- a/rts/src/eta/runtime/io/MemoryManager.java
+++ b/rts/src/eta/runtime/io/MemoryManager.java
@@ -27,7 +27,7 @@ public class MemoryManager {
 
     public static synchronized ByteBuffer allocateBuffer(int n, int address, boolean direct) {
         ByteBuffer buf = allocateAnonymousBuffer(n, direct);
-        buf.putInt(adddress);
+        buf.putInt(address);
         return buf;
     }
     /* Use if you want to allocate a buffer that won't be using the getAddress

--- a/rts/src/eta/runtime/io/MemoryManager.java
+++ b/rts/src/eta/runtime/io/MemoryManager.java
@@ -13,14 +13,23 @@ public class MemoryManager {
     private static TreeMap<Integer, WeakReference<ByteBuffer>> addressMap =
         new TreeMap<Integer, WeakReference<ByteBuffer>>();
 
+    /* Special buffer to represent null pointer in eta. Only contains
+       the address -1 */
+
+    public static final ByteBuffer nullAddress = allocateBuffer(0,-1,false);
+
     public static synchronized ByteBuffer allocateBuffer(int n, boolean direct) {
-        ByteBuffer buf = allocateAnonymousBuffer(n, direct);
-        buf.putInt(nextAddress);
+        ByteBuffer buf = allocateBuffer(n, nextAddress, direct);
         addressMap.put(nextAddress, new WeakReference<ByteBuffer>(buf));
         nextAddress += n;
         return buf;
     }
 
+    public static synchronized ByteBuffer allocateBuffer(int n, int address, boolean direct) {
+        ByteBuffer buf = allocateAnonymousBuffer(n, direct);
+        buf.putInt(adddress);
+        return buf;
+    }
     /* Use if you want to allocate a buffer that won't be using the getAddress
        method and you don't want to pollute the addressMap. */
     public static synchronized ByteBuffer allocateAnonymousBuffer(int n, boolean direct) {
@@ -49,11 +58,7 @@ public class MemoryManager {
     }
 
     public static int getAddress(ByteBuffer buf) {
-        if (buf == null) {
-            return -1;
-        } else {
-            return buf.getInt(0) + getPosition(buf);
-        }
+        return buf.getInt(0) + getPosition(buf);
     }
 
     public static int getPosition(ByteBuffer buf) {


### PR DESCRIPTION
To fix the bug #268 
I've tested manually with this [code](https://github.com/jneira/eta-test/blob/master/app/Main.hs):
```haskell
main = do
  putStrLn $ "nullPtr: " ++ show nullPtr
  let (fptr,offset,length) = BSInt.toForeignPtr B.empty
  withForeignPtr fptr $ \ ptr -> do
    trace ptr offset length
    putStrLn $ "ptr: " ++ show ptr
    putStrLn $ "ptr == nullPtr " ++ (show $ nullPtr == ptr)
  putStrLn $ "ByteString.empty: " ++  show B.empty
  putStrLn $ "Wai request: " ++ show defaultRequest
```
with this output:
```
Ptr: java.nio.HeapByteBuffer[pos=4 lim=4 cap=4]
Ofset: 0
Length: 0
nullPtr: 0xffffffff
ptr: 0xffffffff
ptr == nullPtr True
ByteString.empty: ""
Wai request: Request {requestMethod = "GET", httpVersion = HTTP/1.0, rawPathInfo = "", rawQueryString = "", requestHeaders = [], isSecure = False, remoteHost = 0.0.0.0:0, pathInfo = [], queryString = [], requestBody = <IO ByteString>, vault = <Vault>, requestBodyLength = KnownLength 0, requestHeaderHost = Nothing, requestHeaderRange = Nothing}
```