### PR TITLE
Implement DelayOp

### DIFF
--- a/compiler/ETA/CodeGen/Prim.hs
+++ b/compiler/ETA/CodeGen/Prim.hs
@@ -326,6 +326,12 @@ shouldInlinePrimOp' _ NewMVarOp _ = Right $ return
 shouldInlinePrimOp' _ IsEmptyMVarOp [mvar] = Right $ return
   [ intCompOp ifnull [mvar <> mVarValue] ]
 
+shouldInlinePrimOp' _ DelayOp [time] = Right $
+  let millis = time <> iconst jint 1000 <> idiv <> gconv jint jlong
+      nanos = time <> iconst jint 1000 <> irem
+                   <> iconst jint 1000 <> imul
+  in return [ normalOp (invokestatic (mkMethodRef "java/lang/Thread" "sleep" [jlong, jint] void)) [millis, nanos] ]
+
 shouldInlinePrimOp' _ MakeStableNameOp args = Right $ return
   [ normalOp (invokestatic (mkMethodRef "java/lang/System" "identityHashCode" [jobject] (ret jint))) args ]
 

--- a/libraries/base/GHC/Conc/IO.hs
+++ b/libraries/base/GHC/Conc/IO.hs
@@ -204,4 +204,4 @@ registerDelay usecs
 
 -- foreign import ccall unsafe "rtsSupportsBoundThreads"
 threaded :: Bool
-threaded = undefined
+threaded = False


### PR DESCRIPTION
Also sets threading to False for GHC.Conc.IO so that the op is used for things
like threadDelay. Should instead use the Event version, once we implement
evented IO.