### PR TITLE
Fail on type variable in Java monad tag position.

### DIFF
--- a/compiler/ETA/TypeCheck/TcForeign.hs
+++ b/compiler/ETA/TypeCheck/TcForeign.hs
@@ -13,6 +13,7 @@ module ETA.TypeCheck.TcForeign
  -- , tcCheckFEType
   ) where
 
+import Control.Monad ( when )
 import ETA.BasicTypes.DataCon
 import ETA.BasicTypes.Unique
 import ETA.BasicTypes.SrcLoc
@@ -226,6 +227,8 @@ checkForeignRes nonIOResultOk checkSafe predResType ty
   | Just (_, tagType, resType) <- tcSplitJavaType_maybe ty
   = do
       traceTc "checkForeignRes[Java]" $ ppr tagType <+> ppr resType
+      when (isTyVarTy tagType)
+        (failWithTc (text "Cannot have a type variable in the tag position of the Java monad for exports."))
       check (predResType resType) (illegalForeignTyErr result)
   -- Case for non-IO result type with FFI Import
   | not nonIOResultOk = addErrTc

--- a/compiler/ETA/TypeCheck/TcForeign.hs
+++ b/compiler/ETA/TypeCheck/TcForeign.hs
@@ -383,7 +383,7 @@ tcCheckFEType sigType exportspec = do
     mapM_ (\(_, tagType, _) ->
       when (isTyVarTy tagType)
         (failWithTc (text "Cannot have a type variable in the tag position of the Java monad for exports."))
-      ) tcSplitJavaType_maybe resType
+      ) (tcSplitJavaType_maybe resType)
     checkForeignArgs isFFIExternalTy argTypes
     checkForeignRes nonIOok noCheckSafe isFFIExportResultTy resType
     return exportspec

--- a/compiler/ETA/TypeCheck/TcForeign.hs
+++ b/compiler/ETA/TypeCheck/TcForeign.hs
@@ -227,8 +227,6 @@ checkForeignRes nonIOResultOk checkSafe predResType ty
   | Just (_, tagType, resType) <- tcSplitJavaType_maybe ty
   = do
       traceTc "checkForeignRes[Java]" $ ppr tagType <+> ppr resType
-      when (isTyVarTy tagType)
-        (failWithTc (text "Cannot have a type variable in the tag position of the Java monad for exports."))
       check (predResType resType) (illegalForeignTyErr result)
   -- Case for non-IO result type with FFI Import
   | not nonIOResultOk = addErrTc
@@ -382,6 +380,10 @@ tcFExport d = pprPanic "tcFExport" (ppr d)
 tcCheckFEType :: Type -> ForeignExport -> TcM ForeignExport
 tcCheckFEType sigType exportspec = do
 -- (CExport (L l (CExportStatic str cconv)) src)
+    mapM_ (\(_, tagType, _) ->
+      when (isTyVarTy tagType)
+        (failWithTc (text "Cannot have a type variable in the tag position of the Java monad for exports."))
+      ) tcSplitJavaType_maybe resType
     checkForeignArgs isFFIExternalTy argTypes
     checkForeignRes nonIOok noCheckSafe isFFIExportResultTy resType
     return exportspec

--- a/tests/basic/foreign-export/FailExport.hs
+++ b/tests/basic/foreign-export/FailExport.hs
@@ -1,0 +1,11 @@
+module FailExport where
+
+import Java
+
+foreign export java fib :: Int -> Java a Int
+
+fib n = return $ fib' n
+
+fib' 0 = 1
+fib' 1 = 1
+fib' n = fib' (n - 1) + fib' (n - 2)


### PR DESCRIPTION
For issue https://github.com/typelead/eta/issues/77.

Looks like this.
```
[1 of 2] Compiling Fib              ( Fib.hs, dist/build/proglet/proglet-tmp/Fib.jar )

Fib.hs:5:1:
    Cannot have a type variable in the tag position of the Java monad for exports.
    When checking declaration:
      foreign export java "fib" fib :: Int -> Java a Int
```