### PR TITLE
Fix ArrayIndexOutOfBoundsException with unicode strings

### DIFF
--- a/libraries/ghc-prim/GHC/CString.hs
+++ b/libraries/ghc-prim/GHC/CString.hs
@@ -111,7 +111,7 @@ unpackCStringUtf8# str
   = unpack 0#
   where
     !bytes = getBytesUtf8# str
-    !len = strLength str
+    !len = alength# bytes
     unpack nh
       | isTrue# (nh ==# len) = []
       | isTrue# (ch `leChar#` '\x7F'#) = C# ch : unpack (nh +# 1#)

--- a/tests/basic/unicode/Unicode.hs
+++ b/tests/basic/unicode/Unicode.hs
@@ -1,0 +1,10 @@
+module Main where
+
+main :: IO ()
+main = do
+  putStrLn "7"
+  putStrLn "S"
+  putStrLn "△"
+  putStrLn "☃"
+  putStrLn "¥"
+  putStrLn "n̂"


### PR DESCRIPTION
Fixes https://github.com/typelead/eta/issues/180.