### PR TITLE
Wip/eta 338

### DIFF
--- a/libraries/base/GHC/Conc/Sync.hs
+++ b/libraries/base/GHC/Conc/Sync.hs
@@ -359,10 +359,9 @@ this value, use 'setNumCapabilities'.
 
 @since 4.4.0.0
 -}
-getNumCapabilities :: IO Int
-getNumCapabilities = do
-   n <- peek enabled_capabilities
-   return (fromIntegral n)
+foreign import java unsafe
+  "@static @field eta.runtime.stg.Capability.enabledCapabilities"
+  getNumCapabilities :: IO Int
 
 {- |
 Set the number of Haskell threads that can run truly simultaneously
@@ -383,7 +382,7 @@ setNumCapabilities i = c_setNumCapabilities (fromIntegral i)
 
 -- foreign import ccall safe "setNumCapabilities"
 c_setNumCapabilities :: CUInt -> IO ()
-c_setNumCapabilities = undefined
+c_setNumCapabilities = error $ "setNumCapabilities: unimplemented"
 
 -- | Returns the number of CPUs that the machine has
 --
@@ -391,17 +390,12 @@ c_setNumCapabilities = undefined
 getNumProcessors :: IO Int
 getNumProcessors = fmap fromIntegral c_getNumberOfProcessors
 
--- foreign import ccall unsafe "getNumberOfProcessors"
-c_getNumberOfProcessors :: IO CUInt
-c_getNumberOfProcessors = undefined
+foreign import java unsafe "@static eta.runtime.RtsFlags.getNumberOfProcessors"
+  c_getNumberOfProcessors :: IO CUInt
 
 -- | Returns the number of sparks currently in the local spark pool
 numSparks :: IO Int
 numSparks = IO $ \s -> case numSparks# s of (# s', n #) -> (# s', I# n #)
-
--- foreign import ccall "&enabled_capabilities"
-enabled_capabilities :: Ptr CInt
-enabled_capabilities = undefined
 
 childHandler :: SomeException -> IO ()
 childHandler err = catchException (real_handler err) childHandler

--- a/rts/src/eta/runtime/Rts.java
+++ b/rts/src/eta/runtime/Rts.java
@@ -17,6 +17,8 @@ import static eta.runtime.RtsScheduler.scheduleWaitThread;
 import static eta.runtime.RtsMessages.errorBelch;
 import static eta.runtime.RtsMessages.debugBelch;
 import static eta.runtime.stg.StgTSO.TSO_LOCKED;
+import static eta.runtime.stg.StgTSO.TSO_BLOCKEX;
+import static eta.runtime.stg.StgTSO.TSO_INTERRUPTIBLE;
 
 public class Rts {
     public static class HaskellResult {
@@ -298,6 +300,14 @@ public class Rts {
         if (task != null) {
             task.runningFinalizers = false;
         }
+    }
+
+    public static StgTSO scheduleIOClosure(StgClosure closure) {
+        Capability cap = Capability.getFreeRunningCapability();
+        StgTSO tso = Rts.createIOThread(cap, closure);
+        tso.addFlags(TSO_BLOCKEX | TSO_INTERRUPTIBLE);
+        Rts.scheduleThread(cap, tso);
+        return tso;
     }
 
     public static void scheduleThread(Capability cap, StgTSO tso) {

--- a/rts/src/eta/runtime/RtsFlags.java
+++ b/rts/src/eta/runtime/RtsFlags.java
@@ -67,7 +67,7 @@ public class RtsFlags {
     }
 
     public static void initDefaults() {
-        RtsFlags.ModeFlags.threaded              = false;
+        RtsFlags.ModeFlags.threaded              = true;
         RtsFlags.ModeFlags.userSignals           = false;
         RtsFlags.GcFlags.doIdleGC                = false;
         RtsFlags.GcFlags.squeezeUpdFrames        = true;

--- a/rts/src/eta/runtime/RtsIO.java
+++ b/rts/src/eta/runtime/RtsIO.java
@@ -68,11 +68,12 @@ public class RtsIO {
     }
 
     public static void ioManagerStart() {
+        // TODO: Implement IO manager
         // Check file descriptors or SelectKeys
-        Capability cap = Rts.lock();
-        HaskellResult result = cap.ioManagerStart();
-        cap = result.cap;
-        Rts.unlock(cap);
+        // Capability cap = Rts.lock();
+        // HaskellResult result = cap.ioManagerStart();
+        // cap = result.cap;
+        // Rts.unlock(cap);
     }
 
     public static void ioManagerWakeup() {

--- a/rts/src/eta/runtime/RtsMessages.java
+++ b/rts/src/eta/runtime/RtsMessages.java
@@ -47,7 +47,7 @@ public class RtsMessages {
 
     public static void debugBelch(String msg, Object... args) {
         if (RtsFlags.DebugFlags.scheduler) {
-            System.out.print("[Eta-RTS]" + Thread.currentThread() + ": ");
+            System.out.print("[Eta-RTS] " + Thread.currentThread() + ": ");
         }
         System.out.format(msg, args);
         System.out.print("\n");

--- a/rts/src/eta/runtime/concurrent/Concurrent.java
+++ b/rts/src/eta/runtime/concurrent/Concurrent.java
@@ -205,9 +205,7 @@ public class Concurrent {
             Capability cap = context.myCapability;
             StgTSO currentTSO = context.currentTSO;
             StgClosure closure = context.R(1);
-            StgTSO tso = Rts.createIOThread(cap, closure);
-            tso.addFlags(currentTSO.flags & (TSO_BLOCKEX | TSO_INTERRUPTIBLE));
-            Rts.scheduleThread(cap, tso);
+            StgTSO tso = Rts.scheduleIOClosure(closure);
             cap.contextSwitch = true;
             context.O(1, tso);
         }
@@ -221,7 +219,7 @@ public class Concurrent {
             int cpu = context.I(1);
             StgClosure closure = context.R(1);
             StgTSO tso = Rts.createIOThread(cap, closure);
-            tso.addFlags(currentTSO.flags & (TSO_BLOCKEX | TSO_INTERRUPTIBLE));
+            tso.addFlags(TSO_BLOCKEX | TSO_INTERRUPTIBLE);
             Rts.scheduleThreadOn(cap, cpu, tso);
             cap.contextSwitch = true;
             context.O(1, tso);

--- a/rts/src/eta/runtime/stg/Capability.java
+++ b/rts/src/eta/runtime/stg/Capability.java
@@ -1,6 +1,7 @@
 package eta.runtime.stg;
 
 import java.util.List;
+import java.util.LinkedList;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.ListIterator;
@@ -972,8 +973,7 @@ public final class Capability {
         /* Find the index of the update frame to stop at */
         int stopIndex = -1;
         if (stopHere != null) {
-            Stack<StackFrame> stack = tso.stack;
-            stopIndex = stack.size() - stack.search(stopHere);
+            stopIndex = tso.stack.lastIndexOf(stopHere);
         }
 
         boolean shouldContinue = true;
@@ -1899,7 +1899,6 @@ public final class Capability {
     }
 
     public final void threadStackUnderflow(StgTSO tso) {
-        Stack<StackFrame> oldStack = tso.stack;
         /* TODO: Finish implementation */
     }
 

--- a/rts/src/eta/runtime/stg/StgStopThread.java
+++ b/rts/src/eta/runtime/stg/StgStopThread.java
@@ -2,6 +2,7 @@ package eta.runtime.stg;
 
 import java.util.Deque;
 import java.util.Stack;
+import java.util.LinkedList;
 import java.util.ListIterator;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,7 +44,7 @@ public class StgStopThread extends StackFrame {
     @Override
     public boolean doRaise(StgContext context, Capability cap, StgTSO tso, StgClosure exception) {
         tso.stack.clear();
-        Stack<StackFrame> stack = new Stack<StackFrame>();
+        LinkedList<StackFrame> stack = new LinkedList<StackFrame>();
         tso.stack = stack;
         tso.sp = stack.listIterator();
         tso.spPush(new StgEnter(exception));

--- a/rts/src/eta/runtime/stg/StgTSO.java
+++ b/rts/src/eta/runtime/stg/StgTSO.java
@@ -5,6 +5,7 @@ import java.util.Deque;
 import java.util.Queue;
 import java.util.ArrayDeque;
 import java.util.List;
+import java.util.LinkedList;
 import java.util.ListIterator;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -28,7 +29,7 @@ public final class StgTSO extends StgClosure {
     public static AtomicInteger maxThreadId = new AtomicInteger(0);
     public int id = nextThreadId();
     public volatile StgTSO link;
-    public Stack<StackFrame> stack = new Stack<StackFrame>();
+    public LinkedList<StackFrame> stack = new LinkedList<StackFrame>();
     public ListIterator<StackFrame> sp;
     public Queue<StgBlockingQueue> blockingQueues = new ArrayDeque<StgBlockingQueue>();
     public WhatNext whatNext = ThreadRunGHC;

--- a/rts/src/eta/runtime/stg/StgTSO.java
+++ b/rts/src/eta/runtime/stg/StgTSO.java
@@ -119,7 +119,7 @@ public final class StgTSO extends StgClosure {
     public final void removeFromMVarBlockedQueue() {
         StgMVar mvar = (StgMVar) blockInfo;
         if (!inMVarOperation) return;
-        mvar.tsoQueue.remove(this);
+        // mvar.tsoQueue.remove(this);
         inMVarOperation = false;
     }
 

--- a/rts/src/eta/runtime/stg/Task.java
+++ b/rts/src/eta/runtime/stg/Task.java
@@ -123,7 +123,9 @@ public class Task {
         Task task = allocTask();
         task.stopped = false;
         task.newInCall();
-        //debugTrace
+        if (RtsFlags.DebugFlags.scheduler) {
+            debugBelch("New Task (task count: %d)", allTasks.size());
+        }
         return task;
     }
 
@@ -143,9 +145,7 @@ public class Task {
         } else {
             task = new Task(false);
             task.initialize();
-            if (RtsFlags.ModeFlags.threaded) {
-                task.id = Thread.currentThread().getId();
-            }
+            task.id = Thread.currentThread().getId();
             setMyTask(task);
             return task;
         }
@@ -186,7 +186,7 @@ public class Task {
             }
             cap.assertFullCapabilityInvariants(this);
             if (RtsFlags.DebugFlags.scheduler) {
-                debugBelch("resuming capability %d", cap.no);
+                debugBelch("Resuming Capability[%d].", cap.no);
             }
         } else {
             mainCapability.runningTask = this;
@@ -243,11 +243,15 @@ public class Task {
     }
 
     public void boundTaskExiting() {
+        assert Thread.currentThread().getId() == id;
+        assert myTask() == this;
         endInCall();
         if (incall == null) {
             stopped = true;
         }
-        //debugTrace
+        if (RtsFlags.DebugFlags.scheduler) {
+            debugBelch("Task[%d] exiting.", id);
+        }
     }
 
     public void endInCall() {

--- a/rts/src/eta/runtime/stg/Task.java
+++ b/rts/src/eta/runtime/stg/Task.java
@@ -165,7 +165,7 @@ public class Task {
             }
 
             if (RtsFlags.DebugFlags.scheduler) {
-                debugBelch("returning; I want capability %d", cap.no);
+                debugBelch("Waiting for Capability[%d].", cap.no);
             }
             Lock l = cap.lock;
             boolean unlocked = false;
@@ -307,8 +307,7 @@ public class Task {
             try {
                 if (cap.runningTask != null) {
                     if (RtsFlags.DebugFlags.scheduler) {
-                        debugBelch("capabilitity %d is owned by another task",
-                                   cap.no);
+                        debugBelch("Capability[%d] is owned by another task.", cap.no);
                     }
                     l.unlock();
                     unlocked = true;


### PR DESCRIPTION
This primarily resolves #338, so Eta now has basic concurrency. 

Details:
- If you run `forkIO` more than say N times, where N is the value of the `+RTS -N[N]` flag you send when you run the program, there is no guarantee that your forked threads' tasks will be given fairness in CPU time. If you use it less than N times, you are guaranteed that the tasks will run separately. See #358.
- The threaded runtime is now default because no one writes useful non-concurrent applications anymore.
- MVar is implemented to work with the new `forkIO` change. STM primitives need to updated, see #360.
- A minor data structure change was made making the Eta stack use a `LinkedList` instead of a `Stack`. The result was a 20-30% increase in performance across the board, with an increase in GC allocation rate by up to 2x in some cases. This can be addressed with an intrusive list implementation, but for now the JVM GC is good enough to handle it.

[Before](https://circleci.com/gh/typelead/eta-benchmarks/45#tests/containers/0) and [After](https://circleci.com/gh/typelead/eta-benchmarks/46#build-timing/containers/0) (Click on `./eta-benchmarks.sh`)

Some sample entries here:

Benchmark | Before (ms) | After (ms)
--- | --- | ---
`imaginary/exp3_8` | 1018 | 718
`imaginary/wheel-sieve1` | 3585 | 2522
`spectral/lambda` | 9341 | 6542

