### PR TITLE
Auto docker

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,15 +17,20 @@ dependencies:
     - ~/.local
     - ~/.etlas
     - ~/.coursier
+    - ./.stack-work
+    - ./etlas/etlas/.stack-work
 
   pre:
     - mkdir -p ~/.local/bin
 
   override:
     - ./install.sh
+    - ./docker/circleci-build-container.sh build
+    - stack build --test --no-run-tests eta
 
 test:
   override:
+    - echo "Running tests"
     - stack test eta
 
   post:
@@ -33,3 +38,22 @@ test:
     - ./utils/scripts/circleci-trigger.sh typelead/eta-examples master $ETA_EXAMPLES_TOKEN $CIRCLE_BRANCH $CIRCLE_TAG $CI_PULL_REQUEST
     - ./utils/scripts/circleci-trigger.sh typelead/eta-benchmarks master $ETA_BENCHMARKS_TOKEN $CIRCLE_BRANCH $CIRCLE_TAG $CI_PULL_REQUEST
     - ./utils/scripts/circleci-trigger.sh rahulmutt/eta-2048 master $ETA_2048_TOKEN $CIRCLE_BRANCH $CIRCLE_TAG $CI_PULL_REQUEST
+
+deployment:
+  release:
+    owner: typelead
+    branch: [master]
+    commands:
+      - ./docker/circleci-build-container.sh push latest
+
+  development:
+    owner: typelead
+    branch: /.*/
+    commands:
+      - ./docker/circleci-build-container.sh push $CIRCLE_BRANCH
+
+  forks:
+    branch: /.*/
+    commands:
+      - echo "Fork branch deployment"
+      # - ./docker/circleci-build-container.sh push $CIRCLE_BRANCH

--- a/circle.yml
+++ b/circle.yml
@@ -17,8 +17,7 @@ dependencies:
     - ~/.local
     - ~/.etlas
     - ~/.coursier
-    - ./.stack-work
-    - ./etlas/etlas/.stack-work
+    - ~/eta/.stack-work
 
   pre:
     - mkdir -p ~/.local/bin

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,67 @@
+FROM ubuntu:xenial
+MAINTAINER Sibi Prabakaran <sibi@psibi.in>
+
+# Oracle stuff taken and modified from https://github.com/davidcaste/docker-debian-oracle-java/blob/master/8/jdk/Dockerfile
+
+ENV JAVA_VERSION_MAJOR=8 \
+    JAVA_VERSION_MINOR=92 \
+    JAVA_VERSION_BUILD=14 \
+    JAVA_PACKAGE=jdk \
+    JAVA_HOME=/opt/java \
+    JVM_OPTS="" \
+    LANG=C.UTF-8
+
+RUN apt-get update -q && \
+    apt-get install -q -y --no-install-recommends ca-certificates dnsutils less ssh sudo curl unzip cabal-install libbz2-dev git zlib1g-dev build-essential && \
+    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
+      http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
+    gunzip /tmp/java.tar.gz && \
+    tar -C /opt -xf /tmp/java.tar && \
+    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
+    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/unlimited_jce_policy.zip "http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip" && \
+    unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/unlimited_jce_policy.zip && \
+    rm -rf ${JAVA_HOME}/*src.zip \
+           ${JAVA_HOME}/lib/missioncontrol \
+           ${JAVA_HOME}/lib/visualvm \
+           ${JAVA_HOME}/lib/*javafx* \
+           ${JAVA_HOME}/jre/plugin \
+           ${JAVA_HOME}/jre/bin/javaws \
+           ${JAVA_HOME}/jre/bin/jjs \
+           ${JAVA_HOME}/jre/bin/keytool \
+           ${JAVA_HOME}/jre/bin/orbd \
+           ${JAVA_HOME}/jre/bin/pack200 \
+           ${JAVA_HOME}/jre/bin/policytool \
+           ${JAVA_HOME}/jre/bin/rmid \
+           ${JAVA_HOME}/jre/bin/rmiregistry \
+           ${JAVA_HOME}/jre/bin/servertool \
+           ${JAVA_HOME}/jre/bin/tnameserv \
+           ${JAVA_HOME}/jre/bin/unpack200 \
+           ${JAVA_HOME}/jre/lib/javaws.jar \
+           ${JAVA_HOME}/jre/lib/deploy* \
+           ${JAVA_HOME}/jre/lib/desktop \
+           ${JAVA_HOME}/jre/lib/*javafx* \
+           ${JAVA_HOME}/jre/lib/*jfx* \
+           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
+           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
+           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
+           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
+           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
+           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
+           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
+           ${JAVA_HOME}/jre/lib/oblique-fonts \
+           ${JAVA_HOME}/jre/lib/plugin.jar \
+           /tmp/* /var/cache/apk/* && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN useradd -ms /bin/bash ubuntu && \
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    adduser ubuntu sudo
+ADD bin/ /home/ubuntu/
+RUN chown -R ubuntu:ubuntu /home/ubuntu
+
+USER ubuntu
+WORKDIR /home/ubuntu
+ENV PATH=${PATH}:/opt/java/bin:/home/ubuntu/.local/bin

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,22 @@
+# Building ETA docker container in Circle CI
+This folder contains everything necessary to automatically build and publish Eta/Etlas docker container in CI.
+
+## Requirements
+The following CircleCI env variables are expected to be set:
+
+`DOCKER_EMAIL`, `DOCKER_USER`, `DOCKER_PASS` - these are used for `docker login` that is needed for `docker push`.
+
+## Publishing rules
+By default the target repository will be inferred from the GIT repository name, i.e. containers that are built from `https://github.com/typelead/eta` will be pushed as `typelead/eta:<tag>`.
+This behavior can be changed by setting `DOCKER_REPO` env variable to override the default setting. For example, setting `DOCKER_REPO` to `quay.io/jdoe/myrepo` will result pushing to that docker repository.
+
+## Results and tags
+The contaner is pushed as:
+
+- `<docker-repo>:<git-hash>` - is pushed always
+- `<docker-repo>:<git-tag>` - is pushed if the commit that is being built is tagged
+- `<docker-repo>:<git-branch>` - is pushed for branches other than `master` (see `circle.yaml`)
+- `<docker-repo>:latest` - is pushed when `master` branch is built.
+
+Note that the same container in the same build can have multiple docker tags. For example, when `master` branch is built, the container is pushed with two tags: `<docker-repo>:<git-hash>` and `<docker-repo>:latest`. And if the commit was tagged as well then it will also have `<docker-repo>:<git-tag>` tag.
+See `circle.yaml` and `circleci-build-container.sh` for more details.

--- a/docker/circleci-build-container.sh
+++ b/docker/circleci-build-container.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+if [ "$DOCKER_EMAIL" == "" ] || [ "$DOCKER_USER" == "" ] || [ "$DOCKER_PASS" == "" ]; then
+  echo "DOCKER_EMAIL, DOCKER_USER and DOCKER_PASS variables are not set."
+  echo "Will not build and push docker container."
+  exit 0
+fi
+
+CURRENT_TAG=$(git describe --exact-match --tags $(git log -n1 --pretty='%h') 2> /dev/null || echo "")
+CURRENT_VER=$(cat *.cabal | grep -e "^name" | tr -s " " | cut -d' ' -f2)
+CURRENT_HASH=$(git rev-parse --short HEAD)
+
+DOCKER_REPO=$(echo ${DOCKER_REPO:-"$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"} | tr '[:upper:]' '[:lower:]')
+echo "Docker repo: $DOCKER_REPO"
+
+HASH_TAG="$DOCKER_REPO:$CURRENT_HASH"
+
+EXTRA_TAG=$(echo ${2:-''} | tr '[:upper:]' '[:lower:]')
+
+case $1 in
+  build)
+    set -e
+    mkdir -p ./docker/bin/.local
+    cp -r ~/.local/bin ./docker/bin/.local/
+    cp -r ~/.eta ./docker/bin/
+    cp -r ~/.etlas ./docker/bin/
+    rm -rf ./docker/bin/.etlas/logs/*
+    rm -rf ./docker/bin/.etlas/packages/*
+
+    echo "Building an image: $HASH_TAG"
+    docker build -t $HASH_TAG ./docker
+    set +e
+  ;;
+
+  push)
+    set -e
+    echo "Logging into docker"
+    docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+
+    echo "Push: $HASH_TAG"
+    docker push $HASH_TAG
+
+    if [ "$CURRENT_TAG" ]; then
+      echo "Push: $DOCKER_REPO:$CURRENT_TAG"
+      docker tag $HASH_TAG "$DOCKER_REPO:$CURRENT_TAG"
+      docker push "$DOCKER_REPO:$CURRENT_TAG"
+    fi
+    if [ "$EXTRA_TAG" ]; then
+        echo "Push: $DOCKER_REPO:$EXTRA_TAG"
+        docker tag $HASH_TAG "$DOCKER_REPO:$EXTRA_TAG"
+        docker push "$DOCKER_REPO:$EXTRA_TAG"
+    fi
+    set +e
+  ;;
+esac

--- a/utils/scripts/circleci-trigger.sh
+++ b/utils/scripts/circleci-trigger.sh
@@ -5,6 +5,11 @@ _project=$1
 _branch=$2
 _circle_token=$3
 
+if [ "$_circle_token" == "" ]; then
+  echo "Skip triggering $_project"
+  exit 0
+fi
+
 trigger_build_url=https://circleci.com/api/v1.1/project/github/${_project}/tree/${_branch}?circle-token=${_circle_token}
 
 post_data=$(cat <<EOF


### PR DESCRIPTION
## Changes

Build and publish Eta/Etlas docker container automatically.
This allows us always having a container with the latest version of Eta. This container can be conveniently used as a primary CCI build container for other Eta libraries (I'll add the instructions and an example later).

The container doesn't contain `~/.etlas/packages` so `etlas update` is expected (which would be expected anyway).

To enable auto publishing containers please set `DOCKER_EMAIL`, `DOCKER_USER` and `DOCKER_PASS` in CircleCI environment variables.

Container is pushed to docker hub as `typelead/eta:<git hash>`. 
When `master` is built, `typelead/eta:latest` is also published. Otherwies `typelead/eta:<branch-name>` is published.
If the commit is tagged, then `typelead/eta:tag` is also published.

See `docker/README.md` for more info.