### PR TITLE
latest jdk

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,17 +4,21 @@ MAINTAINER Sibi Prabakaran <sibi@psibi.in>
 # Oracle stuff taken and modified from https://github.com/davidcaste/docker-debian-oracle-java/blob/master/8/jdk/Dockerfile
 
 ENV JAVA_VERSION_MAJOR=8 \
-    JAVA_VERSION_MINOR=92 \
-    JAVA_VERSION_BUILD=14 \
-    JAVA_PACKAGE=jdk \
+    JAVA_VERSION_MINOR=131 \
+    JAVA_VERSION_BUILD=11 \
+    JAVA_PACKAGE=d54c1d3a095b4ff2b6607d096fa80163 \
     JAVA_HOME=/opt/java \
     JVM_OPTS="" \
     LANG=C.UTF-8
 
 RUN apt-get update -q && \
     apt-get install -q -y --no-install-recommends ca-certificates dnsutils less ssh sudo curl unzip cabal-install libbz2-dev git zlib1g-dev build-essential && \
-    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
-      http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
+    rm -rf /var/cache/apk/* && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
+      http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}/jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
     gunzip /tmp/java.tar.gz && \
     tar -C /opt -xf /tmp/java.tar && \
     ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
@@ -52,9 +56,7 @@ RUN apt-get update -q && \
            ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
            ${JAVA_HOME}/jre/lib/oblique-fonts \
            ${JAVA_HOME}/jre/lib/plugin.jar \
-           /tmp/* /var/cache/apk/* && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+           /var/tmp/*
 
 RUN useradd -ms /bin/bash ubuntu && \
     echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \


### PR DESCRIPTION
## Changes

Oracle has removed the ability to download `JDK 8.92.14` and, as it seems, has changed the structure of the download URL. 
This PR is to use the latest `JDK 8.131.11` in a docker container.