### PR TITLE
Make line buffering default for `stdout`

### DIFF
--- a/libraries/base/GHC/IO/Handle.hs
+++ b/libraries/base/GHC/IO/Handle.hs
@@ -639,7 +639,7 @@ dupHandle_ :: (IODevice dev, BufferedIO dev, Typeable dev) => dev
 dupHandle_ new_dev filepath other_side h_@Handle__{..} mb_finalizer = do
    -- XXX wrong!
   mb_codec <- if isJust haEncoder then fmap Just getLocaleEncoding else return Nothing
-  mkHandle new_dev filepath haType True{-buffered-} mb_codec
+  mkHandle new_dev filepath haType (BlockBuffering Nothing) mb_codec
       NewlineMode { inputNL = haInputNL, outputNL = haOutputNL }
       mb_finalizer other_side
 

--- a/libraries/base/GHC/IO/Handle.hs
+++ b/libraries/base/GHC/IO/Handle.hs
@@ -639,7 +639,11 @@ dupHandle_ :: (IODevice dev, BufferedIO dev, Typeable dev) => dev
 dupHandle_ new_dev filepath other_side h_@Handle__{..} mb_finalizer = do
    -- XXX wrong!
   mb_codec <- if isJust haEncoder then fmap Just getLocaleEncoding else return Nothing
-  mkHandle new_dev filepath haType (BlockBuffering Nothing) mb_codec
+  is_tty <- IODevice.isTerminal new_dev
+  let buffer_mode
+         | is_tty = LineBuffering
+         | otherwise = BlockBuffering Nothing
+  mkHandle new_dev filepath haType buffer_mode mb_codec
       NewlineMode { inputNL = haInputNL, outputNL = haOutputNL }
       mb_finalizer other_side
 

--- a/libraries/base/GHC/IO/Handle.hs
+++ b/libraries/base/GHC/IO/Handle.hs
@@ -639,11 +639,7 @@ dupHandle_ :: (IODevice dev, BufferedIO dev, Typeable dev) => dev
 dupHandle_ new_dev filepath other_side h_@Handle__{..} mb_finalizer = do
    -- XXX wrong!
   mb_codec <- if isJust haEncoder then fmap Just getLocaleEncoding else return Nothing
-  is_tty <- IODevice.isTerminal new_dev
-  let buffer_mode
-         | is_tty = LineBuffering
-         | otherwise = BlockBuffering Nothing
-  mkHandle new_dev filepath haType buffer_mode mb_codec
+  mkHandle new_dev filepath haType Nothing mb_codec
       NewlineMode { inputNL = haInputNL, outputNL = haOutputNL }
       mb_finalizer other_side
 

--- a/libraries/base/GHC/IO/Handle/FD.hs
+++ b/libraries/base/GHC/IO/Handle/FD.hs
@@ -53,7 +53,11 @@ stdin = unsafePerformIO $ do
    -- ToDo: acquire lock
    setBinaryMode FD.stdin
    enc <- getLocaleEncoding
-   mkHandle FD.stdin "<stdin>" ReadHandle (BlockBuffering Nothing)
+   is_tty <- IODevice.isTerminal FD.stdin
+   let buffer_mode
+         | is_tty = LineBuffering
+         | otherwise = BlockBuffering Nothing
+   mkHandle FD.stdin "<stdin>" ReadHandle buffer_mode
                 (Just enc)
                 nativeNewlineMode{-translate newlines-}
                 (Just stdHandleFinalizer) Nothing

--- a/libraries/base/GHC/IO/Handle/FD.hs
+++ b/libraries/base/GHC/IO/Handle/FD.hs
@@ -53,7 +53,8 @@ stdin = unsafePerformIO $ do
    -- ToDo: acquire lock
    setBinaryMode FD.stdin
    enc <- getLocaleEncoding
-   mkHandle FD.stdin "<stdin>" ReadHandle True (Just enc)
+   mkHandle FD.stdin "<stdin>" ReadHandle (BlockBuffering Nothing)
+                (Just enc)
                 nativeNewlineMode{-translate newlines-}
                 (Just stdHandleFinalizer) Nothing
 
@@ -64,7 +65,8 @@ stdout = unsafePerformIO $ do
    -- ToDo: acquire lock
    setBinaryMode FD.stdout
    enc <- getLocaleEncoding
-   mkHandle FD.stdout "<stdout>" WriteHandle True (Just enc)
+   mkHandle FD.stdout "<stdout>" WriteHandle (BlockBuffering Nothing)
+                (Just enc)
                 nativeNewlineMode{-translate newlines-}
                 (Just stdHandleFinalizer) Nothing
 
@@ -75,7 +77,7 @@ stderr = unsafePerformIO $ do
     -- ToDo: acquire lock
    setBinaryMode FD.stderr
    enc <- getLocaleEncoding
-   mkHandle FD.stderr "<stderr>" WriteHandle False{-stderr is unbuffered-}
+   mkHandle FD.stderr "<stderr>" WriteHandle NoBuffering{-stderr is unbuffered-}
                 (Just enc)
                 nativeNewlineMode{-translate newlines-}
                 (Just stdHandleFinalizer) Nothing

--- a/libraries/base/GHC/IO/Handle/FD.hs
+++ b/libraries/base/GHC/IO/Handle/FD.hs
@@ -53,11 +53,7 @@ stdin = unsafePerformIO $ do
    -- ToDo: acquire lock
    setBinaryMode FD.stdin
    enc <- getLocaleEncoding
-   is_tty <- IODevice.isTerminal FD.stdin
-   let buffer_mode
-         | is_tty = LineBuffering
-         | otherwise = BlockBuffering Nothing
-   mkHandle FD.stdin "<stdin>" ReadHandle buffer_mode
+   mkHandle FD.stdin "<stdin>" ReadHandle Nothing
                 (Just enc)
                 nativeNewlineMode{-translate newlines-}
                 (Just stdHandleFinalizer) Nothing
@@ -69,7 +65,7 @@ stdout = unsafePerformIO $ do
    -- ToDo: acquire lock
    setBinaryMode FD.stdout
    enc <- getLocaleEncoding
-   mkHandle FD.stdout "<stdout>" WriteHandle LineBuffering
+   mkHandle FD.stdout "<stdout>" WriteHandle (Just LineBuffering)
                 (Just enc)
                 nativeNewlineMode{-translate newlines-}
                 (Just stdHandleFinalizer) Nothing
@@ -81,7 +77,7 @@ stderr = unsafePerformIO $ do
     -- ToDo: acquire lock
    setBinaryMode FD.stderr
    enc <- getLocaleEncoding
-   mkHandle FD.stderr "<stderr>" WriteHandle NoBuffering{-stderr is unbuffered-}
+   mkHandle FD.stderr "<stderr>" WriteHandle (Just NoBuffering){-stderr is unbuffered-}
                 (Just enc)
                 nativeNewlineMode{-translate newlines-}
                 (Just stdHandleFinalizer) Nothing

--- a/libraries/base/GHC/IO/Handle/FD.hs
+++ b/libraries/base/GHC/IO/Handle/FD.hs
@@ -65,7 +65,7 @@ stdout = unsafePerformIO $ do
    -- ToDo: acquire lock
    setBinaryMode FD.stdout
    enc <- getLocaleEncoding
-   mkHandle FD.stdout "<stdout>" WriteHandle (BlockBuffering Nothing)
+   mkHandle FD.stdout "<stdout>" WriteHandle LineBuffering
                 (Just enc)
                 nativeNewlineMode{-translate newlines-}
                 (Just stdHandleFinalizer) Nothing

--- a/libraries/base/GHC/IO/Handle/Internals.hs
+++ b/libraries/base/GHC/IO/Handle/Internals.hs
@@ -625,6 +625,7 @@ mkHandle dev filepath ha_type bmode mb_codec nl finalizer other_side = do
    (cbufref, _) <-
      case bmode of
        BlockBuffering _ -> getCharBuffer dev buf_state
+       LineBuffering -> mkUnBuffer buf_state
        _ -> mkUnBuffer buf_state
 
    spares <- newIORef BufferListNil


### PR DESCRIPTION
I moved the `is_tty` stuff from `getCharBuffer` to where `mkHandle` was being called so I could pass in the buffering mode as a parameter to `mkHandle`.

After that, `mkUnBuffer` and `getCharBuffer` ended up being exactly the same, so I merged them into one.

And then of course pass in line buffering as default for `stdout`.