### PR TITLE
Build Openjdk Slim based container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
             - ~/.stack
 
       - restore_cache:
-          key: stack-work-{{ checksum "stack.yaml" }}
+          key: stack-works-{{ checksum "stack.yaml" }}
 
       - run:
           name: Installing or updating ETA
@@ -43,11 +43,15 @@ jobs:
           paths:
             - ~/.stack
       - save_cache:
-          key: stack-work-{{ checksum "stack.yaml" }}
+          key: stack-works-{{ checksum "stack.yaml" }}
           paths:
             - ~/eta/.stack-work
             - ./etlas/etlas/.stack-work
             - ./etlas/etlas-cabal/.stack-work
+            - ./codec-jvm/.stack-work
+            - ./libraries/eta-boot/.stack-work
+            - ./libraries/eta-boot-th/.stack-work
+            - ./shake/.stack-work
 
       - save_cache:
           key: eta-bin
@@ -93,24 +97,7 @@ jobs:
             tar -xz -C /tmp -f /tmp/docker-$VER.tgz
             mv /tmp/docker/* /usr/bin
       - run: ./docker/circleci-build-container.sh build
-      - run: ./docker/circleci-build-container.sh push latest
-
-  dev_container:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          key: eta-bin
-      - setup_remote_docker
-      - run:
-          name: Install Docker client
-          command: |
-            set -x
-            VER="17.03.0-ce"
-            curl -L -o /tmp/docker-$VER.tgz https://get.docker.com/builds/Linux/x86_64/docker-$VER.tgz
-            tar -xz -C /tmp -f /tmp/docker-$VER.tgz
-            mv /tmp/docker/* /usr/bin
-      - run: ./docker/circleci-build-container.sh build
+      - run: ./docker/circleci-build-container.sh push
 
   trigger_builds:
     <<: *defaults
@@ -135,16 +122,6 @@ workflows:
       - release_container:
           requires:
             - build
-          filters:
-            branches:
-              only: master
-
-      - dev_container:
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: master
 
       - trigger_builds:
           requires:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,62 +1,14 @@
-FROM ubuntu:xenial
+FROM openjdk:8-jdk-slim
 MAINTAINER Sibi Prabakaran <sibi@psibi.in>
 
-# Oracle stuff taken and modified from https://github.com/davidcaste/docker-debian-oracle-java/blob/master/8/jdk/Dockerfile
-
-ENV JAVA_VERSION_MAJOR=8 \
-    JAVA_VERSION_MINOR=131 \
-    JAVA_VERSION_BUILD=11 \
-    JAVA_PACKAGE=d54c1d3a095b4ff2b6607d096fa80163 \
-    JAVA_HOME=/opt/java \
-    JVM_OPTS="" \
-    LANG=C.UTF-8
-
-RUN apt-get update -q && \
-    apt-get install -q -y --no-install-recommends ca-certificates dnsutils less ssh sudo curl unzip cabal-install libbz2-dev git zlib1g-dev build-essential && \
-    rm -rf /var/cache/apk/* && \
+RUN apt-get -q update && \
+    apt-get -q install -y --no-install-recommends git dnsutils && \
+    rm -rf /tmp/* \
+           /var/cache/apk/* && \
+    apt-get autoclean && \
     apt-get clean && \
+    apt-get autoremove && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
-      http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-b${JAVA_VERSION_BUILD}/${JAVA_PACKAGE}/jdk-${JAVA_VERSION_MAJOR}u${JAVA_VERSION_MINOR}-linux-x64.tar.gz && \
-    gunzip /tmp/java.tar.gz && \
-    tar -C /opt -xf /tmp/java.tar && \
-    ln -s /opt/jdk1.${JAVA_VERSION_MAJOR}.0_${JAVA_VERSION_MINOR} ${JAVA_HOME} && \
-    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/unlimited_jce_policy.zip "http://download.oracle.com/otn-pub/java/jce/8/jce_policy-8.zip" && \
-    unzip -jo -d ${JAVA_HOME}/jre/lib/security /tmp/unlimited_jce_policy.zip && \
-    rm -rf ${JAVA_HOME}/*src.zip \
-           ${JAVA_HOME}/lib/missioncontrol \
-           ${JAVA_HOME}/lib/visualvm \
-           ${JAVA_HOME}/lib/*javafx* \
-           ${JAVA_HOME}/jre/plugin \
-           ${JAVA_HOME}/jre/bin/javaws \
-           ${JAVA_HOME}/jre/bin/jjs \
-           ${JAVA_HOME}/jre/bin/keytool \
-           ${JAVA_HOME}/jre/bin/orbd \
-           ${JAVA_HOME}/jre/bin/pack200 \
-           ${JAVA_HOME}/jre/bin/policytool \
-           ${JAVA_HOME}/jre/bin/rmid \
-           ${JAVA_HOME}/jre/bin/rmiregistry \
-           ${JAVA_HOME}/jre/bin/servertool \
-           ${JAVA_HOME}/jre/bin/tnameserv \
-           ${JAVA_HOME}/jre/bin/unpack200 \
-           ${JAVA_HOME}/jre/lib/javaws.jar \
-           ${JAVA_HOME}/jre/lib/deploy* \
-           ${JAVA_HOME}/jre/lib/desktop \
-           ${JAVA_HOME}/jre/lib/*javafx* \
-           ${JAVA_HOME}/jre/lib/*jfx* \
-           ${JAVA_HOME}/jre/lib/amd64/libdecora_sse.so \
-           ${JAVA_HOME}/jre/lib/amd64/libprism_*.so \
-           ${JAVA_HOME}/jre/lib/amd64/libfxplugins.so \
-           ${JAVA_HOME}/jre/lib/amd64/libglass.so \
-           ${JAVA_HOME}/jre/lib/amd64/libgstreamer-lite.so \
-           ${JAVA_HOME}/jre/lib/amd64/libjavafx*.so \
-           ${JAVA_HOME}/jre/lib/amd64/libjfx*.so \
-           ${JAVA_HOME}/jre/lib/ext/jfxrt.jar \
-           ${JAVA_HOME}/jre/lib/ext/nashorn.jar \
-           ${JAVA_HOME}/jre/lib/oblique-fonts \
-           ${JAVA_HOME}/jre/lib/plugin.jar \
-           /var/tmp/*
 
 ADD bin/ /root/
 ENV PATH=${PATH}:/opt/java/bin:/root/.local/bin


### PR DESCRIPTION
## Changes
- Use `openjdk-slim` container instead of Ubuntu+Java8. This reduces the result container size from `521MB` to `177MB`.
- Build docker container in branches. `typelead/eta:latest` tag will be pushed from `master`, `typelead/eta:<branchName>` will be pushed from dev branches.