### PR TITLE
Rename bin caches for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
             - ./shake/.stack-work
 
       - save_cache:
-          key: eta-bin
+          key: eta-bin-{{ .Revision }}
           paths:
             - ~/.eta
             - ~/.etlas
@@ -72,7 +72,7 @@ jobs:
           at: .
 
       - restore_cache:
-          key: eta-bin
+          key: eta-bin-{{ .Revision }}
 
       - restore_cache:
           keys:
@@ -93,7 +93,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: eta-bin
+          key: eta-bin-{{ .Revision }}
       - setup_remote_docker
       - run:
           name: Install Docker client


### PR DESCRIPTION
## Changes
- Cache eta bins for tests per-revision


## Testing
The build proceeds successfully in a fork: https://circleci.com/gh/AlexeyRaga/eta/110
I think that `typelead/eta/master` might have a CI cache issue and I hope that this PR fixes it.

## Note
The test build fails anyway, but the failure seems legit: `directory` package is not patched.