### PR TITLE
Emitting line numbers in code generation

### DIFF
--- a/compiler/ETA/CodeGen/Expr.hs
+++ b/compiler/ETA/CodeGen/Expr.hs
@@ -345,7 +345,5 @@ cgAlgAltRhss binder alts = do
 cgTick :: Tickish Id -> CodeGen ()
 cgTick (SourceNote srcSpan _) = do
   let srcLoc = realSrcSpanStart srcSpan
-  traceCg (str $ "StgTick , tickish: SourceNote, srcSpan: " ++ show srcSpan)
   addLineNumber $ srcLocLine srcLoc
-  setSourceFileName $ fastStringText $ srcLocFile srcLoc
 cgTick _ = return ()

--- a/compiler/ETA/CodeGen/Expr.hs
+++ b/compiler/ETA/CodeGen/Expr.hs
@@ -38,8 +38,13 @@ cgExpr (StgOpApp op args ty) = traceCg (str "StgOpApp" <+> ppr op <+> ppr args <
                                cgOpApp op args ty
 cgExpr (StgConApp con args) = traceCg (str "StgConApp" <+> ppr con <+> ppr args) >>
                               cgConApp con args
--- TODO: Deal with ticks
-cgExpr (StgTick t e) = traceCg (str "StgTick" <+> ppr t) >> cgExpr e
+
+cgExpr (StgTick t e) = do
+  traceCg (str "StgTick" <+> ppr t)
+  cgTick t
+  cgExpr e
+
+  
 cgExpr (StgLit lit) = emitReturn [mkLocDirect False $ cgLit lit]
 cgExpr (StgLet binds expr) = do
   forbidScoping (cgBind binds)
@@ -319,3 +324,7 @@ cgAlgAltRhss binder alts = do
       allBranches = [ (getDataConTag con, code)
                     | (DataAlt con, code) <- taggedBranches ]
   return (maybeDefault, branches)
+
+cgTick :: Tickish Id -> CodeGen ()
+cgTick (SourceNote srcSpan srcName) = undefined
+cgTick _ = return ()

--- a/compiler/ETA/CodeGen/Expr.hs
+++ b/compiler/ETA/CodeGen/Expr.hs
@@ -40,10 +40,12 @@ preCgExpr :: StgExpr -> CodeGen StgExpr
 preCgExpr e@(StgTick _ _) = return e 
 preCgExpr expr = do
   mbLn <- getInnermostLineNumber
-  let ln = fmap mkLineNumber mbLn
-  traceCg (str $ "Emitting line number: " ++ show ln)
-  emit $ maybe mempty emitLineNumber ln
-  resetLineNumbers
+  case mbLn of
+    Just ln -> do
+      traceCg (str $ "StgExpr emitting line number: " ++ show ln)
+      emit $ emitLineNumber $ mkLineNumber ln
+      resetLineNumbers
+    Nothing -> return ()
   return expr
   
 doCgExpr :: StgExpr -> CodeGen ()
@@ -343,7 +345,7 @@ cgAlgAltRhss binder alts = do
 cgTick :: Tickish Id -> CodeGen ()
 cgTick (SourceNote srcSpan _) = do
   let srcLoc = realSrcSpanStart srcSpan
-  traceCg (str $ "SourceNote, srcSpan: " ++ show srcSpan)
+  traceCg (str $ "StgTick , tickish: SourceNote, srcSpan: " ++ show srcSpan)
   addLineNumber $ srcLocLine srcLoc
   setSourceFileName $ fastStringText $ srcLocFile srcLoc
 cgTick _ = return ()

--- a/compiler/ETA/CodeGen/Expr.hs
+++ b/compiler/ETA/CodeGen/Expr.hs
@@ -344,11 +344,14 @@ cgAlgAltRhss binder alts = do
 
 cgTick :: Tickish a -> CodeGen ()
 cgTick (SourceNote srcSpan _) = do
-  mbCgSrcFile <- getSourceFileName
-  case mbCgSrcFile of
-    Just cgSrcFile -> do
+  mbCgFilePath <- getSourceFilePath
+  case mbCgFilePath of
+    Just cgFilePath -> do
       let srcLoc  = realSrcSpanStart srcSpan
-          srcFile = fastStringText $ srcLocFile srcLoc
-      when (srcFile == cgSrcFile) $ addLineNumber $ srcLocLine srcLoc
+          srcFile = show $ srcLocFile srcLoc
+      traceCg (str $ "StgTick: tickish, adding line number [SrcSpan: srcFile $" ++
+               srcFile ++ "$, cgFile: $" ++ cgFilePath ++
+               "$, match source files: " ++ show (srcFile == cgFilePath)  ++"]")
+      when (srcFile == cgFilePath) $ addLineNumber $ srcLocLine srcLoc
     Nothing -> return ()
 cgTick _ = return ()

--- a/compiler/ETA/CodeGen/Expr.hs
+++ b/compiler/ETA/CodeGen/Expr.hs
@@ -342,8 +342,13 @@ cgAlgAltRhss binder alts = do
                     | (DataAlt con, code) <- taggedBranches ]
   return (maybeDefault, branches)
 
-cgTick :: Tickish Id -> CodeGen ()
+cgTick :: Tickish a -> CodeGen ()
 cgTick (SourceNote srcSpan _) = do
-  let srcLoc = realSrcSpanStart srcSpan
-  addLineNumber $ srcLocLine srcLoc
+  mbCgSrcFile <- getSourceFileName
+  case mbCgSrcFile of
+    Just cgSrcFile -> do
+      let srcLoc  = realSrcSpanStart srcSpan
+          srcFile = fastStringText $ srcLocFile srcLoc
+      when (srcFile == cgSrcFile) $ addLineNumber $ srcLocLine srcLoc
+    Nothing -> return ()
 cgTick _ = return ()

--- a/compiler/ETA/CodeGen/Main.hs
+++ b/compiler/ETA/CodeGen/Main.hs
@@ -40,14 +40,15 @@ import Control.Monad hiding (void)
 
 import Data.Text (Text, pack, append)
 
-codeGen :: HscEnv -> Module -> [TyCon] -> [StgBinding] -> HpcInfo
+codeGen :: HscEnv -> Module -> ModLocation
+        -> [TyCon] -> [StgBinding] -> HpcInfo
         -> Maybe ([MethodDef], [FieldDef]) -> IO [ClassFile]
-codeGen hscEnv thisMod dataTyCons stgBinds _hpcInfo mMFs = do
+codeGen hscEnv thisMod thisModLoc dataTyCons stgBinds _hpcInfo mMFs = do
   runCodeGen mMFs env state $ do
     mapM_ (cgTopBinding dflags) stgBinds
     mapM_ cgTyCon dataTyCons
   where
-    (env, state) = initCg dflags thisMod
+    (env, state) = initCg dflags thisMod thisModLoc
     dflags = hsc_dflags hscEnv
 
 cgTopBinding :: DynFlags -> StgBinding -> CodeGen ()

--- a/compiler/ETA/CodeGen/Monad.hs
+++ b/compiler/ETA/CodeGen/Monad.hs
@@ -57,6 +57,7 @@ module ETA.CodeGen.Monad
    addLineNumber,
    resetLineNumbers,
    getInnermostLineNumber,
+   getSourceFileName,
    setSourceFileName)
 where
 
@@ -523,6 +524,9 @@ getInnermostLineNumber :: CodeGen (Maybe Int)
 getInnermostLineNumber =  do
   lns <- gets cgLineNumbers
   return $ listToMaybe lns
+
+getSourceFileName :: CodeGen (Maybe Text)
+getSourceFileName = gets cgSourceFileName
 
 setSourceFileName :: Text -> CodeGen ()
 setSourceFileName name =  modify $ \s@CgState{..} ->

--- a/compiler/ETA/CodeGen/Monad.hs
+++ b/compiler/ETA/CodeGen/Monad.hs
@@ -101,6 +101,7 @@ data CgState =
           , cgFieldDefs      :: ![FieldDef]
           , cgClassName      :: !Text
           , cgSuperClassName :: !(Maybe Text)
+          , cgSourceFileName :: !(Maybe Text)
           -- Current method
           , cgCode           :: !Code
           , cgScopedBindings :: CgBindings
@@ -167,6 +168,7 @@ initCg dflags mod =
            , cgMethodDefs          = []
            , cgFieldDefs           = []
            , cgClassName           = className
+           , cgSourceFileName      = Nothing
            , cgCompiledClosures    = []
            , cgRecursiveInitNumber = 0
            , cgSuperClassName      = Nothing

--- a/compiler/ETA/Core/PprCore.hs
+++ b/compiler/ETA/Core/PprCore.hs
@@ -510,8 +510,8 @@ instance Outputable id => Outputable (Tickish id) where
          (True,True)  -> hcat [ptext (sLit "scctick<"), ppr cc, char '>']
          (True,False) -> hcat [ptext (sLit "tick<"),    ppr cc, char '>']
          _            -> hcat [ptext (sLit "scc<"),     ppr cc, char '>']
-  ppr (SourceNote span _) =
-      hcat [ ptext (sLit "src<"), pprUserRealSpan True span, char '>']
+  ppr (SourceNote span name) =
+      hcat [ptext (sLit name), ptext (sLit " <"), pprUserRealSpan True span, char '>']
 
 {-
 -----------------------------------------------------

--- a/compiler/ETA/Main/DynFlags.hs
+++ b/compiler/ETA/Main/DynFlags.hs
@@ -2797,7 +2797,7 @@ dynamic_flags = [
   , defGhcFlag "fno-PIC"       (NoArg (unSetGeneralFlag Opt_PIC))
 
          ------ Debugging flags ----------------------------------------------
-  , defGhcFlag "g"             (NoArg (setGeneralFlag Opt_Debug))
+  , defGhcFlag "g"             (OptIntSuffix setDebugLevel)
          ------ Eta-specific flags -------------------------------------------
  ]
  ++ map (mkFlag turnOn  ""     setGeneralFlag  ) negatableFlags
@@ -3311,7 +3311,8 @@ defaultFlags _
       Opt_ProfCountEntries,
       Opt_RPath,
       Opt_SharedImplib,
-      Opt_SimplPreInlining
+      Opt_SimplPreInlining,
+      Opt_Debug
     ]
 
     ++ [f | (ns,f) <- optLevelFlags, 0 `elem` ns]
@@ -3732,6 +3733,11 @@ setVerboseCore2Core = setDumpFlag' Opt_D_verbose_core2core
 
 setVerbosity :: Maybe Int -> DynP ()
 setVerbosity mb_n = upd (\dfs -> dfs{ verbosity = mb_n `orElse` 3 })
+
+setDebugLevel :: Maybe Int -> DynP ()
+setDebugLevel (Just 0) = unSetGeneralFlag Opt_Debug
+setDebugLevel _ = setGeneralFlag Opt_Debug
+
 
 addCmdlineHCInclude :: String -> DynP ()
 addCmdlineHCInclude a = upd (\s -> s{cmdlineHcIncludes =  a : cmdlineHcIncludes s})

--- a/compiler/ETA/Main/HscMain.hs
+++ b/compiler/ETA/Main/HscMain.hs
@@ -1215,7 +1215,7 @@ hscGenHardCode hsc_env cgguts mod_summary output_filename = do
                myCoreToStg dflags this_mod prepd_binds
 
         let modClass = moduleJavaClass this_mod
-        modClasses <- codeGen hsc_env this_mod data_tycons stg_binds hpc_info
+        modClasses <- codeGen hsc_env this_mod location data_tycons stg_binds hpc_info
                               (lookupStubs modClass foreign_stubs)
         let stubClasses = outputForeignStubs dflags foreign_stubs modClass
             classes = stubClasses ++ modClasses

--- a/rts/src/eta/runtime/concurrent/Concurrent.java
+++ b/rts/src/eta/runtime/concurrent/Concurrent.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.nio.ByteBuffer;
 import java.nio.channels.Channel;
 import java.nio.channels.Selector;
 import java.nio.channels.SelectionKey;
@@ -22,6 +23,7 @@ import eta.runtime.stg.Capability;
 import eta.runtime.stg.TSO;
 import eta.runtime.stg.Closure;
 import eta.runtime.stg.StgContext;
+import eta.runtime.io.MemoryManager;
 import eta.runtime.exception.Exception;
 import static eta.runtime.RuntimeLogging.barf;
 import static eta.runtime.stg.TSO.*;
@@ -143,6 +145,14 @@ public class Concurrent {
 
     /* TODO: Implement this */
     public static Closure traceEvent(StgContext context) {
+        return null;
+    }
+
+    public static Closure labelThread(StgContext context, TSO tso, long address) {
+        ByteBuffer buffer = MemoryManager.getBoundedBuffer(address);
+        byte[]     bytes  = new byte[buffer.remaining() - 1];
+        buffer.get(bytes);
+        tso.setName(new String(bytes));
         return null;
     }
 

--- a/rts/src/eta/runtime/stg/TSO.java
+++ b/rts/src/eta/runtime/stg/TSO.java
@@ -251,4 +251,13 @@ public final class TSO extends BlackHole {
         cap.idleLoop(false);
         whyBlocked = NotBlocked;
     }
+
+    public final void setName(String name) {
+        if (cap != null) {
+            Thread t = cap.thread.get();
+            if (t != null) {
+                t.setName(name);
+            }
+        }
+    }
 }

--- a/shake/Build.hs
+++ b/shake/Build.hs
@@ -102,7 +102,7 @@ buildLibrary debug binPathArg lib _deps = do
                   ++ nonNullString (binPathArg "../../")
       configureFlags = if debug
                        then ["--enable-optimization=0"
-                            ,"--eta-options=-ddump-to-file -ddump-stg -dumpdir=dump"]
+                            ,"--eta-options=-g -ddump-to-file -ddump-stg -dumpdir=dump"]
                        else ["--enable-optimization=2"]
 
       -- libCmd = unit . cmd (Cwd dir)

--- a/tests/verify/win-verify.cmd
+++ b/tests/verify/win-verify.cmd
@@ -1,0 +1,31 @@
+@echo off
+:: (Re)build the Verify.java script and copy the class file here
+echo Building the Verify script...
+javac ../../utils/class-verifier/Verify.java || exit /b
+copy ..\..\utils\class-verifier\Verify.class . 
+echo Verify.class built successfully.
+
+:: Remove old build artifacts
+rmdir build /S /Q
+
+:: Compile a simple program and extract the files
+echo Compiling a simple program...
+echo === Eta Compiler Output ===
+mkdir build
+eta -fforce-recomp -o build/Out.jar Main.hs || exit /b
+echo ===                     ===
+echo Compiled succesfully.
+
+:: Do bytecode verification on all the core libraries' class files
+echo Verifying the bytecode of compiled program...
+echo === Verify Script Output ===
+java Verify build/Out.jar || exit /b
+echo ===                      ===
+echo Bytecode looking good.
+
+:: Make sure a simple "Hello World!" program runs
+echo Running the simple program...
+echo === Simple Program Output ===
+java -cp build/Out.jar eta.main || exit /b
+echo ===                       ===
+echo Done! Everything's looking good.


### PR DESCRIPTION
[#189] Some considerations:
* it adds some overhead to cgExpr when no SourceNote's are generated (without -g flag?): it checks the list of line numbers for every cgExpr evaluation
* the name of the source file is put in every SourceNote expr, when should be the same for the class being generated
* the name of source file contains the relative os-specific path (f.e. `.\GHC\Err.hs`). We have to determine what should be the best name. If we follow the [jvm bytecode spec](https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.10):
> The string referenced by the sourcefile_index item will be interpreted as indicating the name of the source file from which this class file was compiled. It will not be interpreted as indicating the name of a directory containing the file or an absolute path name for the file; such platform-specific additional information must be supplied by the run-time interpreter or development tool at the time the file name is actually used. 

... the name should be Err.hs but it is less helpful than indicating the full module name in some way

I've compiled base with the version and i've got this stracktrace:
```
D:\ws\eta\eta\examples>java -jar RunHelloWorld.jar
Hello World!
Exception in thread "main" eta.runtime.exception.EtaException: Testing stacktraces
        at base.ghc.Err$error.enter(.\GHC\Err.hs:35)
        at main.Main$$Ls1LWsat.thunkEnter(HelloWorld.hs:5)
        at eta.runtime.thunk.CAF.enter(CAF.java:31)
        at eta.runtime.thunk.Thunk.applyV(Thunk.java:121)
        at base.ghc.Base$thenIO1.enter(./GHC/Base.hs:1073)
        at eta.runtime.apply.PAP.apply(PAP.java:31)
        at eta.runtime.apply.PAP.applyV(PAP.java:41)
        at eta.runtime.stg.Closures$EvalLazyIO.enter(Closures.java:100)
        at eta.runtime.stg.Capability.schedule(Capability.java:153)
        at eta.runtime.stg.Capability.scheduleClosure(Capability.java:100)
        at eta.runtime.Runtime.evalLazyIO(Runtime.java:189)
        at eta.runtime.Runtime.main(Runtime.java:182)
        at eta.main.main(Unknown Source)
```
* I've run the verify script (the new windows version) and it seems to check the class 