### PR TITLE
MemoryManager faster getbuffer

### DIFF
--- a/rts/src/eta/runtime/stm/STM.java
+++ b/rts/src/eta/runtime/stm/STM.java
@@ -212,7 +212,7 @@ public class STM {
                 tso.resetStack();
                 return ret;
             } else {
-                throw e;
+                throw (RuntimeException) e;
             }
         }
     }

--- a/rts/src/eta/runtime/thunk/CAF.java
+++ b/rts/src/eta/runtime/thunk/CAF.java
@@ -37,7 +37,7 @@ public class CAF extends Thunk {
                         if (((EtaAsyncException) e).stopHere == ui) {
                             continue;
                         } else {
-                            throw e;
+                            throw (EtaAsyncException) e;
                         }
                     } else {
                         EtaException e_;

--- a/rts/src/eta/runtime/thunk/UpdatableThunk.java
+++ b/rts/src/eta/runtime/thunk/UpdatableThunk.java
@@ -24,7 +24,7 @@ public abstract class UpdatableThunk extends Thunk {
                         if (((EtaAsyncException) e).stopHere == ui) {
                             continue;
                         } else {
-                            throw e;
+                            throw (EtaAsyncException) e;
                         }
                     } else {
                         EtaException e_;


### PR DESCRIPTION
I found than reducing the number of thread local access improve the running time of https://github.com/jbgi/partial-evaluation/ by ~10 to 15%.