### PR TITLE
Handling relinking using persistent link info

### DIFF
--- a/compiler/ETA/Main/DriverPipeline.hs
+++ b/compiler/ETA/Main/DriverPipeline.hs
@@ -1316,8 +1316,7 @@ linkingNeeded dflags linkables pkgDeps = do
                           , lib <- packageHsLibs dflags c ]
           pkgLibFiles <- mapM (uncurry $ findHSLib dflags) pkgHSLibs
           if any isNothing pkgLibFiles then do
-             debugTraceMsg dflags 3 (text $ "linkingNeeded: any isNothing pkgLibFiles = " ++
-                                     show jarTimes)
+             debugTraceMsg dflags 3 (text $ "linkingNeeded: any isNothing pkgLibFiles")
              return True
           else do
             extras <- getExtrasFileName dflags


### PR DESCRIPTION
As commented in #609 we need to trigger the linker phase of eta if some of the values affecting the link phase change. In this way we could get eta to do a relinking when switching between uberjar and normal mode, as required in #582. 
Following loosely ghc behaviour the linker phase data is stored in the executable as a file named `.eta-link-info` in the main jar built.
The info collected is:
* The compression method: changing it requires a relink
* The paths to all files involved:
  * The main class and manifest: they are fixed but changing between lib and executable modes will trigger a relink
  * The object jars with the compiled eta modules
  * The jars of packages on which it depends if they should be included
  * The jars informed as linkable objects and the `__extras.jar` with the java and class files ones

* All the info is hashed to avoid leaks of info about the file system:
  * For most files the hash is done with the file path: compute the hash with the content of all of them could be expensive; it means the link will be trigged on file path changes and no on real content ones.
  * But this version is using the hash for the content for `__extras.jar`, with the class and java files, so we get a relinking when those files change, as required in #594
* Before comparing the last link info stored in the exe jar file and the new one, eta was checking if the linkables or packages jars had been modified after the last exe jar file. This version has added the input jars in that check but no `__extras.jar` cause it is always generated.

Maybe those changes in the linker phase makes unnecessary cleaning the dist dir when change between uberjar and normal mode (#285)