### PR TITLE
#669  building shake package  panic FIX - working but not _understandable_ solution

### DIFF
--- a/compiler/ETA/CodeGen/Expr.hs
+++ b/compiler/ETA/CodeGen/Expr.hs
@@ -157,11 +157,7 @@ cgIdApp funId args = do
     JumpToIt label cgLocs mLne -> do
       traceCg (str "cgIdApp: JumpToIt")
       deps <- dependencies args
-      traceCg (str "J:cgLocs:" <+> ppr cgLocs)
-      traceCg (str $ "J:cgLocsL:" ++ show ( length cgLocs )  ++ " depsL:" ++ show ( length deps )  )
-      traceCg (str $ "J:argsL:" ++ show ( length args ))
-      traceCg (str "J:args:" <+> ppr args)
-      emitMultiAssign cgLocs deps
+      emitMultiAssign $ zipWith (\loc dep -> AnyAssignment{from = dep, to = loc}) cgLocs deps
       emit $ maybe  mempty
                       (\(target, targetLoc) ->
                        storeLoc targetLoc (iconst (locFt targetLoc) $ fromIntegral target))

--- a/compiler/ETA/CodeGen/Expr.hs
+++ b/compiler/ETA/CodeGen/Expr.hs
@@ -156,8 +156,8 @@ cgIdApp funId args = do
       withContinuation contCode lastCode
     JumpToIt label cgLocs mLne -> do
       traceCg (str "cgIdApp: JumpToIt")
-      deps <- dependencies $ zip args cgLocs
-      emitMultiAssign  deps
+      deps <- dependencies args
+      emitMultiAssign $ zipWith (\loc dep -> AnyAssignment{from = dep, to = loc}) cgLocs deps
       emit $ maybe  mempty
                       (\(target, targetLoc) ->
                        storeLoc targetLoc (iconst (locFt targetLoc) $ fromIntegral target))
@@ -165,26 +165,26 @@ cgIdApp funId args = do
                   <>   goto label
 
     where
-        dependencies::[(StgArg,CgLoc)]->CodeGen [Assignment]
+        dependencies::[StgArg]->CodeGen [Either Code CgLoc]
         dependencies  [] =  pure []
         dependencies (arg:args)
-          | isVoidRep (argPrimRep $ fst arg) = dependencies args
+          | isVoidRep (argPrimRep arg) = dependencies args
           | otherwise = dependencies args  >>=  joinDependency  arg
 
-        joinDependency :: (StgArg,CgLoc)->[Assignment] -> CodeGen [Assignment]
+        joinDependency :: StgArg->[Either Code CgLoc] -> CodeGen [Either Code CgLoc]
         joinDependency  x deps =
             joinSingle  deps  <$> dep
             where dep = dependency x
 
-        joinSingle :: [Assignment]->Assignment->[Assignment]
+        joinSingle :: [Either Code CgLoc]->Either Code CgLoc->[Either Code CgLoc]
         joinSingle  deps x = x : deps
 
-        dependency::(StgArg,CgLoc)->CodeGen Assignment
-        dependency (arg,loc) = getGetDepCgLoad (NonVoid arg, loc)
+        dependency::StgArg->CodeGen (Either Code CgLoc)
+        dependency arg = getGetDepCgLoad (NonVoid arg)
 
-        getGetDepCgLoad :: (NonVoid StgArg, CgLoc) -> CodeGen Assignment
-        getGetDepCgLoad (NonVoid (StgVarArg var), loc) = (\x -> AnyAssignment{ from=Right x, to =loc  }) <$> cgLocation <$> getCgIdInfo var
-        getGetDepCgLoad (NonVoid (arg) ,loc) = (\x ->AnyAssignment{ from =Left x, to = loc}) <$> getArgLoadCode (NonVoid arg)
+        getGetDepCgLoad :: NonVoid StgArg -> CodeGen (Either Code CgLoc)
+        getGetDepCgLoad (NonVoid (StgVarArg var)) = Right <$> cgLocation <$> getCgIdInfo var
+        getGetDepCgLoad (NonVoid (arg)) = Left <$> getArgLoadCode (NonVoid arg)
 
 
 emitEnter :: CgLoc -> CodeGen ()

--- a/compiler/ETA/CodeGen/Expr.hs
+++ b/compiler/ETA/CodeGen/Expr.hs
@@ -157,6 +157,10 @@ cgIdApp funId args = do
     JumpToIt label cgLocs mLne -> do
       traceCg (str "cgIdApp: JumpToIt")
       deps <- dependencies args
+      traceCg (str "J:cgLocs:" <+> ppr cgLocs)
+      traceCg (str $ "J:cgLocsL:" ++ show ( length cgLocs )  ++ " depsL:" ++ show ( length deps )  )
+      traceCg (str $ "J:argsL:" ++ show ( length args ))
+      traceCg (str "J:args:" <+> ppr args)
       emitMultiAssign cgLocs deps
       emit $ maybe  mempty
                       (\(target, targetLoc) ->

--- a/compiler/ETA/CodeGen/Layout.hs
+++ b/compiler/ETA/CodeGen/Layout.hs
@@ -36,7 +36,7 @@ emitAssign cgLoc code = emit $ storeLoc cgLoc code
 multiAssign :: [CgLoc] -> [Code] -> Code
 multiAssign locs codes = fold $ zipWith storeLoc locs codes
 
--- generic way - might be used fod "any" code or known vars
+-- generic way - might be used for "any" code or known vars
 emitMultiAssign  :: [CgLoc] -> [Either Code CgLoc] -> CodeGen ()
 emitMultiAssign stores exprs =  (emit $ multiAssign (fst  codes) (snd codes) ) >> emitMultiAssignVars (fst  locs)  (snd locs)
 --emitMultiAssign stores exprs =  (emit $ multiAssign stores exprs ) >> emitMultiAssignVars []  []
@@ -112,7 +112,7 @@ codesOnly [] [] = ([], [])
 codesOnly (storeHead:stores) (Left exprHead:exprs) = ( storeHead : fst tail, exprHead : snd tail)
     where tail = codesOnly stores exprs
 codesOnly  (_:stores) (Right _:exprs) = codesOnly stores exprs
-codesOnly _ _ = panic "unequal assigmnents"
+codesOnly _ _ = panic "unequal assignments a1"
 
 -- so bad copy paste almost
 cgLocsOnly:: [CgLoc] -> [Either Code CgLoc] -> ([CgLoc], [CgLoc])
@@ -120,7 +120,7 @@ cgLocsOnly [] [] = ([], [])
 cgLocsOnly (storeHead:stores) (Right exprHead:exprs) = ( storeHead : fst tail, exprHead : snd tail)
     where tail = cgLocsOnly stores exprs
 cgLocsOnly  (_:stores) (Left _:exprs) = cgLocsOnly stores exprs
-cgLocsOnly _ _ = panic "unequal assigmnents"
+cgLocsOnly _ _ = panic "unequal assignments a2"
 
 findVarId::CgLoc->[Int]
 findVarId (LocLocal _ _ x) = [x]

--- a/compiler/ETA/CodeGen/Layout.hs
+++ b/compiler/ETA/CodeGen/Layout.hs
@@ -27,39 +27,49 @@ emitReturn results = do
   loadContext <- getContextLoc
   case sequel of
       Return         -> emit $ mkReturnExit loadContext results <> greturn closureType
-      AssignTo slots -> emitMultiAssign slots (map Right results)
+      AssignTo slots -> emitMultiAssign $ zipWith (\slot res -> AnyAssignment{from=res, to=slot}) slots (map toCode results)
+
+toCode::CgLoc->(Either Code CgLoc)
+toCode x = Right x
+
 
 emitAssign :: CgLoc -> Code -> CodeGen ()
 emitAssign cgLoc code = emit $ storeLoc cgLoc code
 
+
+data AnyAssignment a = AnyAssignment { to :: CgLoc, from :: a }
+type Assignment = (AnyAssignment (Either Code CgLoc))
+type Statement = (AnyAssignment CgLoc)
+type CodeAssignment = (AnyAssignment Code)
+-- data Assignment a = Assignment { to :: CgLoc, from :: [Either Code CgLoc] }
+
+
 -- this code is called after locs and codes are sorted topologically
-multiAssign :: [CgLoc] -> [Code] -> Code
-multiAssign locs codes = fold $ zipWith storeLoc locs codes
+multiAssign :: [CodeAssignment] -> Code
+multiAssign assignments = fold $  map ( \AnyAssignment{from=from, to =to} -> storeLoc to from ) assignments
+
+
 
 -- generic way - might be used for "any" code or known vars
-emitMultiAssign  :: [CgLoc] -> [Either Code CgLoc] -> CodeGen ()
-emitMultiAssign stores exprs =  (emit $ multiAssign (fst  codes) (snd codes) ) >> emitMultiAssignVars (fst  locs)  (snd locs)
---emitMultiAssign stores exprs =  (emit $ multiAssign stores exprs ) >> emitMultiAssignVars []  []
+emitMultiAssign::[Assignment] -> CodeGen ()
+emitMultiAssign assignments =  (emit $ multiAssign codes ) >> emitMultiAssignVars locs
     where
-        codes = codesOnly stores exprs
-        locs = cgLocsOnly stores exprs
--- emitMultiAssign (storeHead:stores) (Left exprHead:exprs) = multiAssign storeHead
--- emitMultiAssign locs codes = fold $ zipWith storeLoc locs codes
+        codes = codesOnly assignments
+        locs = cgLocsOnly assignments
 
-emitMultiAssignVars  :: [CgLoc] -> [CgLoc] -> CodeGen ()
-emitMultiAssignVars stores load = do
-    unscramble $ makeStatements stores load
+emitMultiAssignVars  :: [Statement] -> CodeGen ()
+emitMultiAssignVars assignments = unscramble $ assignments
 
 type Key  = Int
 
-data Statement = Statement { from::CgLoc, to::CgLoc}
+
 
 type Vrtx = (Key, Statement)
 
 makeStatements::[CgLoc]->[CgLoc]->[Statement]
 makeStatements [] [] = []
 makeStatements (toHead:toTail) (fromHead:fromTail) =
-    Statement { from = fromHead, to = toHead} : makeStatements toTail fromTail
+    AnyAssignment { from = fromHead, to = toHead} : makeStatements toTail fromTail
 makeStatements _ _ = panic "not matching stmts"
 
 --  this is more or less close copy of algorithm used in GHC
@@ -95,8 +105,8 @@ unscramble vertices = mapM_ do_component components
             mk_graph from_tmp
 
         split :: CgLoc -> Statement -> (Statement, Statement)
-        split uniq Statement{ from = f, to = t}
-          = (Statement{from=f, to = uniq}, Statement{from = uniq, to =t})
+        split uniq AnyAssignment{ from = f, to = t}
+          = (AnyAssignment{from=f, to = uniq}, AnyAssignment{from = uniq, to =t})
 
         mk_graph :: Statement -> CodeGen ()
         mk_graph stmt = emitAssign (to stmt) code
@@ -107,20 +117,17 @@ emitTemp::CgLoc -> CodeGen CgLoc
 emitTemp (LocLocal isClosure ft _) = newTemp isClosure ft
 emitTemp _ = panic "not implemented"
 
-codesOnly:: [CgLoc] -> [Either Code CgLoc] -> ([CgLoc], [Code])
-codesOnly [] [] = ([], [])
-codesOnly (storeHead:stores) (Left exprHead:exprs) = ( storeHead : fst tail, exprHead : snd tail)
-    where tail = codesOnly stores exprs
-codesOnly  (_:stores) (Right _:exprs) = codesOnly stores exprs
-codesOnly _ _ = panic "unequal assignments a1"
+codesOnly::[Assignment]->[CodeAssignment]
+codesOnly []  = []
+codesOnly ((AnyAssignment{from = Left code, to=to}):tail)  = AnyAssignment{from = code, to = to}: codesOnly tail
+codesOnly (_:tail) =  codesOnly tail
 
--- so bad copy paste almost
-cgLocsOnly:: [CgLoc] -> [Either Code CgLoc] -> ([CgLoc], [CgLoc])
-cgLocsOnly [] [] = ([], [])
-cgLocsOnly (storeHead:stores) (Right exprHead:exprs) = ( storeHead : fst tail, exprHead : snd tail)
-    where tail = cgLocsOnly stores exprs
-cgLocsOnly  (_:stores) (Left _:exprs) = cgLocsOnly stores exprs
-cgLocsOnly _ _ = panic "unequal assignments a2"
+
+cgLocsOnly:: [Assignment] -> [Statement]
+cgLocsOnly []  = []
+cgLocsOnly ((AnyAssignment{from = Right loc, to=to}):tail) =  AnyAssignment{from = loc, to = to}: cgLocsOnly tail
+cgLocsOnly (_:tail) = cgLocsOnly tail
+
 
 findVarId::CgLoc->[Int]
 findVarId (LocLocal _ _ x) = [x]


### PR DESCRIPTION
This seems to fix the compilation problem (file compiles) - I do not know if it works correctly then. I do not have example.

 With this fix all my test projects work and it should work not worse than before fixes than in #603 .

The problem is - this works not as we've agreed. This algorithm ignores last  / non matching cgLocs (as it was done before #603) and removes void args  just from the middle of args - not removing "corresponding" cgLoc.

When I changed it to a _proper_ functionality (my commit https://github.com/jarekratajski/eta/commit/dceadce52fdbee3c959586fb3e7913cf102f51be)
even simple programs started to fail. 

I create this PR in order to give "quick fix" - as I  will not have time for eta in next 3 days.




