### PR TITLE
Allow using ADTs in FFI

### DIFF
--- a/compiler/ETA/DeSugar/DsForeign.hs
+++ b/compiler/ETA/DeSugar/DsForeign.hs
@@ -898,8 +898,6 @@ unboxResult ty resClass resPrimFt
   where resClassFt = obj resClass
 
 
--- TODO (NickSeagull): Take into account the case when a data type has no
--- type constructors like `data Empty`.
 getPrimFt :: Type -> FieldType
 getPrimFt ty = maybe (fromJust $ repFieldType_maybe ty) id (repFieldType_maybe =<< getPrimTyOf ty)
 

--- a/compiler/ETA/DeSugar/DsForeign.hs
+++ b/compiler/ETA/DeSugar/DsForeign.hs
@@ -393,9 +393,7 @@ unboxArg vs arg
       castId <- getClassCastId bound
       let typeArgs = whenExtends bound [argType, tagType]
       unboxArg vs $ mkApps (mkTyApps (Var castId) typeArgs) [Var dictId, arg]
-  | otherwise = do
-      l <- getSrcSpanDs
-      pprPanic "unboxArg: " (ppr l <+> ppr argType)
+  | otherwise = return (argType, arg, id)  --TODO: What are the implications of allowing everything here?  - NickSeagull
   where argType                          = exprType arg
         maybeProductType                 = splitDataProductType_maybe argType
         isProductType                    = isJust maybeProductType
@@ -611,9 +609,8 @@ resultWrapper extendsInfo resultType
        return ( objType
               , \e ->
                   mkApps (Var castId) (typeArgs ++ [Var dictId, wrapper e]))
-  | otherwise
-  = pprPanic "resultWrapper" (ppr resultType)
-  where maybeTcApp = splitTyConApp_maybe resultType
+  | otherwise = return (Just resultType, id)
+  where maybeTcApp = splitTyConApp_maybe resultType  -- TODO: What are the implications of allowing everything here?  - NickSeagull
 
 maybeNarrow :: TyCon -> (CoreExpr -> CoreExpr)
 maybeNarrow tycon


### PR DESCRIPTION
These changes allow to write code like this:

```haskell
data MyADT = MyADT

foo :: MyADT -> Java a ()
foo _ = io $ putStrLn "HI"

bar :: Java a MyADT
bar = return MyADT

foreign export java foo :: MyADT -> Java a ()
foreign export java bar :: Java a MyADT
foreign import java unsafe "some.java.method.that.returns.an.ADT" quux :: MyADT -> Java a ()
```

While we cannot call those methods directly, it is a step towards that Eta from Java interop that we want.