### PR TITLE
Added JChar <-> Char conversion functions to Java.Primitive module

### DIFF
--- a/libraries/base/Java/Primitive.hs
+++ b/libraries/base/Java/Primitive.hs
@@ -17,7 +17,9 @@
 module Java.Primitive
   ( Byte(..)
   , Short(..)
-  , JChar(..) )
+  , JChar(..)
+  , charToJChar
+  , jcharToChar)
 where
 
 import GHC.Base
@@ -28,6 +30,9 @@ import Java.PrimitiveBase
 
 import Data.Data
 import Data.Typeable
+
+import Data.Char
+import Prelude(minBound, maxBound)
 
 deriving instance Typeable Byte
 
@@ -57,6 +62,22 @@ instance Data Short where
 
 deriving instance Typeable JChar
 
+charToJChar :: Char -> Maybe JChar
+charToJChar chr
+    | minJChar <= chrVal && chrVal <= maxJChar = Just $ fromIntegral chrVal
+    | otherwise = Nothing
+    where minJChar = fromIntegral (minBound :: JChar)
+          maxJChar = fromIntegral (maxBound :: JChar)
+          chrVal = ord chr
+
+jcharToChar :: JChar -> Maybe Char
+jcharToChar jchr
+    | minChar <= jchrVal && jchrVal <= maxChar = Just $ chr jchrVal
+    | otherwise = Nothing
+    where minChar = ord (minBound :: Char)
+          maxChar = ord (maxBound :: Char)
+          jchrVal = fromIntegral jchr
+
 jcharType :: DataType
 jcharType = mkIntType "Java.Primitive.JChar"
 
@@ -67,4 +88,3 @@ instance Data JChar where
                     _ -> error $ "Data.Data.gunfold: Constructor " ++ show c
                                  ++ " is not of type JChar."
   dataTypeOf _ = jcharType
-

--- a/libraries/base/Java/Primitive.hs
+++ b/libraries/base/Java/Primitive.hs
@@ -64,10 +64,12 @@ deriving instance Typeable JChar
 
 charToJChar :: Char -> Maybe JChar
 charToJChar chr
-    | chrVal <= maxJChar = Just $ fromIntegral chrVal
+    | chrVal <= maxJChar && not isSurrogate = Just $ fromIntegral chrVal
     | otherwise = Nothing
     where maxJChar = fromIntegral (maxBound :: JChar)
           chrVal = ord chr
+          -- check if Char is reserved UTF-16 value - not a valid JChar
+          isSurrogate = 0xD800 <= chrVal && chrVal <= 0xDFFF
 
 jcharToChar :: JChar -> Maybe Char
 jcharToChar jchr

--- a/libraries/base/Java/Primitive.hs
+++ b/libraries/base/Java/Primitive.hs
@@ -32,7 +32,7 @@ import Data.Data
 import Data.Typeable
 
 import Data.Char
-import Prelude(minBound, maxBound)
+import Prelude(maxBound)
 
 deriving instance Typeable Byte
 

--- a/libraries/base/Java/Primitive.hs
+++ b/libraries/base/Java/Primitive.hs
@@ -64,19 +64,18 @@ deriving instance Typeable JChar
 
 charToJChar :: Char -> Maybe JChar
 charToJChar chr
-    | minJChar <= chrVal && chrVal <= maxJChar = Just $ fromIntegral chrVal
+    | chrVal <= maxJChar = Just $ fromIntegral chrVal
     | otherwise = Nothing
-    where minJChar = fromIntegral (minBound :: JChar)
-          maxJChar = fromIntegral (maxBound :: JChar)
+    where maxJChar = fromIntegral (maxBound :: JChar)
           chrVal = ord chr
 
 jcharToChar :: JChar -> Maybe Char
 jcharToChar jchr
-    | minChar <= jchrVal && jchrVal <= maxChar = Just $ chr jchrVal
-    | otherwise = Nothing
-    where minChar = ord (minBound :: Char)
-          maxChar = ord (maxBound :: Char)
-          jchrVal = fromIntegral jchr
+  | not isSurrogate = Just $ chr jchrVal
+  | otherwise = Nothing
+  where jchrVal = fromIntegral jchr
+        -- check if JChar is reserved UTF-16 value - not a valid character
+        isSurrogate = 0xD800 <= jchrVal && jchrVal <= 0xDFFF
 
 jcharType :: DataType
 jcharType = mkIntType "Java.Primitive.JChar"


### PR DESCRIPTION
I have added JChar <-> Char conversion functions to Java.Primitive module. The functions check that once converted to Int the value falls within the allowed range for the other type and only then converts, otherwise returns Nothing.

I have tried submitting a pull request to master but just found out that it was failing the build test on itself. This should work on stable as I have done some testing on my local machine and built it successfully.

#555