### PR TITLE
Fix `CanceledKeyException` caused by inappropriate handling of `SelectionKey` in `checkForReadyIO()`

### DIFF
--- a/rts/src/main/java/eta/runtime/concurrent/Concurrent.java
+++ b/rts/src/main/java/eta/runtime/concurrent/Concurrent.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Iterator;
+import java.util.ArrayList;
 import java.util.concurrent.Future;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -354,6 +355,7 @@ public class Concurrent {
             if (selectorLock.compareAndSet(false, true)) {
                 try {
                     int selectedKeys = globalSelector.selectNow();
+                    ArrayList<TSO> tsoList = new ArrayList<>();
                     while (selectedKeys > 0) {
                         Iterator<SelectionKey> it = globalSelector.selectedKeys().iterator();
                         while (it.hasNext()) {
@@ -361,16 +363,18 @@ public class Concurrent {
                             if (key.isValid() && ((key.readyOps() & key.interestOps()) != 0)) {
                                 TSO tso = (TSO) key.attachment();
                                 key.cancel();
-                                if(tso.cap==null){
-                                    pushToGlobalRunQueue(tso);
-                                }
-                                else{
-                                    cap.tryWakeupThread(tso);
-                                }
+                                tsoList.add(tso);
                             }
                             it.remove();
                         }
                         selectedKeys = globalSelector.selectNow();
+                    }
+                    for(TSO tso : tsoList){
+                        if(tso.cap==null){
+                            pushToGlobalRunQueue(tso);
+                        }else{
+                            cap.tryWakeupThread(tso);
+                        }
                     }
                 } catch (IOException e) {
                     /* TODO: If the selector is closed, the user should know about it.


### PR DESCRIPTION
The code in `checkForReadyIO` has some problems due to Java NIO's quirk behavior. In Java NIO after a `SelectionKey` is canceled, it isn't really cancelled until the next call to `select()`. And at this time if we try to register the related `Channel` with the `Selector` again, it would throw a `CanceledKeyException`.

Our approach would be to make sure an extra `selectNow()` is called after all the keys are iterated over and "half-canceled". This would involve a while loop to take care of the `Channel`s that are unavoidably selected again, and end when at last `selectNow()` returns 0. Then we can say that every `SelectionKey` is appropriately taken care of, and we can register the `Channel`s without exception as we like.

I'm a bit worried about a race condition though. Say some threads that are woken up in the process and try to register its `Channel` **before** we have the chance to call `selectNow()` and cancel the key appropriately.

If this indeed happens, maybe we need to store all the `TSO`s in a `List` and only try to wake them up after the select loop is finished. Or does there exist a better approach? I'm asking for your opinion here.