### PR TITLE
Nix fixes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,6 @@
-with import <nixpkgs> { };
+{ pkgs ? import (fetchTarball https://nixos.org/channels/nixos-17.09/nixexprs.tar.xz) { } }:
+
+with pkgs;
 
 # To get a shell with all of Eta's dependencies:
 #   $ nix-shell -A eta-build-shell
@@ -20,6 +22,10 @@ let
 
       tasty-ant-xml = haskell.lib.doJailbreak super.tasty-ant-xml;
       binary = haskell.lib.dontCheck self.binary_0_8_5_1 or self.binary_0_8_4_1;
+      hpp = haskell.lib.addExtraLibrary super.hpp self.semigroups;
+
+      # Tests rely on doctest which has problematic semigroups and binary
+      turtle = haskell.lib.dontCheck super.turtle;
 
       codec-jvm = self.callPackage ./utils/nix/codec-jvm.nix { };
       hackage-security = haskell.lib.dontCheck (self.callPackage ./utils/nix/hackage-security.nix { });

--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,9 @@ let
       hackage-security = haskell.lib.dontCheck (self.callPackage ./utils/nix/hackage-security.nix { });
       eta-boot-meta = self.callPackage ./utils/nix/eta-boot-meta.nix { };
       eta-boot = self.callPackage ./utils/nix/eta-boot.nix { };
+      eta-meta = self.callPackage ./utils/nix/eta-meta.nix { };
       eta-pkg = self.callPackage ./utils/nix/eta-pkg.nix { };
+      eta-repl = haskell.lib.dontHaddock (self.callPackage ./utils/nix/eta-repl.nix { });
       etlas-cabal = self.callPackage ./utils/nix/etlas-cabal.nix { };
 
       etlas = haskell.lib.overrideCabal (self.callPackage ./utils/nix/etlas.nix { }) (drv: {

--- a/default.nix
+++ b/default.nix
@@ -31,9 +31,9 @@ let
       hpp = haskell.lib.dontCheck (haskell.lib.addExtraLibrary (self.callPackage ./utils/nix/hpp.nix { }) self.semigroups);
       eta-boot-meta = self.callPackage ./utils/nix/eta-boot-meta.nix { };
       eta-boot = self.callPackage ./utils/nix/eta-boot.nix { };
-      eta-meta = haskell.lib.dontHaddock (self.callPackage ./utils/nix/eta-meta.nix { });
+      eta-meta = self.callPackage ./utils/nix/eta-meta.nix { };
       eta-pkg = self.callPackage ./utils/nix/eta-pkg.nix { };
-      eta-repl = haskell.lib.dontHaddock (self.callPackage ./utils/nix/eta-repl.nix { });
+      eta-repl = self.callPackage ./utils/nix/eta-repl.nix { };
       etlas-cabal = self.callPackage ./utils/nix/etlas-cabal.nix { };
 
       etlas = haskell.lib.overrideCabal (self.callPackage ./utils/nix/etlas.nix { }) (drv: {

--- a/default.nix
+++ b/default.nix
@@ -22,16 +22,16 @@ let
 
       tasty-ant-xml = haskell.lib.doJailbreak super.tasty-ant-xml;
       binary = haskell.lib.dontCheck self.binary_0_8_5_1 or self.binary_0_8_4_1;
-      hpp = haskell.lib.addExtraLibrary super.hpp self.semigroups;
 
       # Tests rely on doctest which has problematic semigroups and binary
       turtle = haskell.lib.dontCheck super.turtle;
 
       codec-jvm = self.callPackage ./utils/nix/codec-jvm.nix { };
       hackage-security = haskell.lib.dontCheck (self.callPackage ./utils/nix/hackage-security.nix { });
+      hpp = haskell.lib.dontCheck (haskell.lib.addExtraLibrary (self.callPackage ./utils/nix/hpp.nix { }) self.semigroups);
       eta-boot-meta = self.callPackage ./utils/nix/eta-boot-meta.nix { };
       eta-boot = self.callPackage ./utils/nix/eta-boot.nix { };
-      eta-meta = self.callPackage ./utils/nix/eta-meta.nix { };
+      eta-meta = haskell.lib.dontHaddock (self.callPackage ./utils/nix/eta-meta.nix { });
       eta-pkg = self.callPackage ./utils/nix/eta-pkg.nix { };
       eta-repl = haskell.lib.dontHaddock (self.callPackage ./utils/nix/eta-repl.nix { });
       etlas-cabal = self.callPackage ./utils/nix/etlas-cabal.nix { };
@@ -48,15 +48,13 @@ let
       });
 
       eta = haskell.lib.overrideCabal (self.callPackage ./utils/nix/eta.nix { }) (drv: {
-        src = onlyFiles ["compiler" "include" "eta" "eta.cabal" "LICENSE"] drv.src;
+        src = onlyFiles ["compiler" "include" "eta" "eta.cabal" "LICENSE" "tests"] drv.src;
         isLibrary = false;
         doCheck = false;
         jailbreak = true;
       });
 
       eta-build = self.callPackage ./utils/nix/eta-build.nix { };
-
-      zip = haskell.lib.dontCheck super.zip;
     };
   };
 

--- a/utils/nix/eta-boot-meta.nix
+++ b/utils/nix/eta-boot-meta.nix
@@ -1,10 +1,9 @@
 { mkDerivation, base, stdenv }:
 mkDerivation {
   pname = "eta-boot-meta";
-  # @VERSION_CHANGE@
   version = "0.8.0";
   src = ../../libraries/eta-boot-meta;
   libraryHaskellDepends = [ base ];
-  description = "Shared functionality between Eta and the @template-haskell@ library";
+  description = "Shared functionality between Eta and the @eta-meta@ library";
   license = stdenv.lib.licenses.bsd3;
 }

--- a/utils/nix/eta-boot.nix
+++ b/utils/nix/eta-boot.nix
@@ -3,7 +3,6 @@
 }:
 mkDerivation {
   pname = "eta-boot";
-  # @VERSION_CHANGE@
   version = "0.8.0";
   src = ../../libraries/eta-boot;
   libraryHaskellDepends = [

--- a/utils/nix/eta-meta.nix
+++ b/utils/nix/eta-meta.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, binary, bytestring, deepseq, eta-boot
+, eta-boot-meta, eta-repl, pretty, stdenv
+}:
+mkDerivation {
+  pname = "eta-meta";
+  version = "0.8.0.3";
+  src = ../../libraries/eta-meta;
+  libraryHaskellDepends = [
+    base binary bytestring deepseq eta-boot eta-boot-meta eta-repl
+    pretty
+  ];
+  description = "Support library for Template Metaprogramming in Eta";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/utils/nix/eta-pkg.nix
+++ b/utils/nix/eta-pkg.nix
@@ -1,18 +1,15 @@
 { mkDerivation, base, binary, bytestring, containers, directory
-, eta-boot, etlas-cabal, filepath, process, stdenv, terminfo, unix
+, eta-boot, etlas-cabal, filepath, stdenv
 }:
 mkDerivation {
   pname = "eta-pkg";
-  # @VERSION_CHANGE@
-  # @BUILD_NUMBER@
-  # @BUILD_NUMBER_INTERNAL@
-  version = "0.8.0.2";
+  version = "0.8.0.3";
   src = ../../utils/eta-pkg;
   isLibrary = false;
   isExecutable = true;
   executableHaskellDepends = [
     base binary bytestring containers directory eta-boot etlas-cabal
-    filepath process terminfo unix
+    filepath
   ];
   description = "A utility for querying and managing the Eta package database";
   license = stdenv.lib.licenses.bsd3;

--- a/utils/nix/eta-repl.nix
+++ b/utils/nix/eta-repl.nix
@@ -1,0 +1,13 @@
+{ mkDerivation, base, binary, bytestring, deepseq, eta-boot-meta
+, stdenv
+}:
+mkDerivation {
+  pname = "eta-repl";
+  version = "0.8.0.2";
+  src = ../../libraries/eta-repl;
+  libraryHaskellDepends = [
+    base binary bytestring deepseq eta-boot-meta
+  ];
+  description = "The library supporting Eta's interactive interpreter";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/utils/nix/eta.nix
+++ b/utils/nix/eta.nix
@@ -1,30 +1,27 @@
-{ mkDerivation, aeson, alex, array, base, bytestring, codec-jvm
-, containers, cpphs, deepseq, directory, eta-boot, eta-boot-meta
-, exceptions, filepath, happy, haskeline, hpc, mtl, path, path-io
-, process, stdenv, text, time, transformers, turtle, unix
+{ mkDerivation, aeson, alex, array, base, binary, bytestring
+, codec-jvm, containers, cpphs, deepseq, directory, eta-boot
+, eta-boot-meta, eta-meta, eta-repl, exceptions, filepath, gitrev
+, happy, haskeline, hpc, hpp, mtl, path, path-io, process
+, semigroups, stdenv, text, time, transformers, turtle, unix
 , unix-compat, zip
 }:
 mkDerivation {
   pname = "eta";
-  # @VERSION_CHANGE@
-  # @BUILD_NUMBER@
-  # @BUILD_NUMBER_INTERNAL@
-  version = "0.8.0.2";
+  version = "0.8.0.3";
   src = ../..;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    array base bytestring codec-jvm containers cpphs deepseq directory
-    eta-boot eta-boot-meta exceptions filepath hpc mtl path path-io
-    process text time transformers unix unix-compat zip
+    array base binary bytestring codec-jvm containers cpphs deepseq
+    directory eta-boot eta-boot-meta eta-meta eta-repl exceptions
+    filepath gitrev hpc hpp mtl path path-io process semigroups text
+    time transformers unix unix-compat zip
   ];
   libraryToolDepends = [ alex happy ];
   executableHaskellDepends = [
-    array base bytestring deepseq directory filepath haskeline process
-    transformers unix
-  ];
-  testHaskellDepends = [
-    aeson base bytestring directory filepath text turtle
+    aeson array base bytestring containers deepseq directory eta-boot
+    eta-repl filepath haskeline process text time transformers turtle
+    unix
   ];
   license = stdenv.lib.licenses.bsd3;
 }

--- a/utils/nix/etlas-cabal.nix
+++ b/utils/nix/etlas-cabal.nix
@@ -3,8 +3,7 @@
 }:
 mkDerivation {
   pname = "etlas-cabal";
-  # @VERSION
-  version = "1.3.0.0";
+  version = "1.4.0.1";
   src = ../../etlas/etlas-cabal;
   libraryHaskellDepends = [
     array base binary bytestring containers deepseq directory filepath

--- a/utils/nix/etlas.nix
+++ b/utils/nix/etlas.nix
@@ -6,8 +6,7 @@
 }:
 mkDerivation {
   pname = "etlas";
-  # @VERSION
-  version = "1.3.0.0";
+  version = "1.4.0.1";
   src = ../../etlas/etlas;
   isLibrary = true;
   isExecutable = true;

--- a/utils/nix/hpp.nix
+++ b/utils/nix/hpp.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, base, bytestring, bytestring-trie, directory
+, fetchgit, filepath, ghc-prim, stdenv, time, transformers
+}:
+mkDerivation {
+  pname = "hpp";
+  version = "0.5.2";
+  src = fetchgit {
+    url = "https://github.com/rahulmutt/hpp.git";
+    sha256 = "1i9hk210cvxflhxsdv0pfxjrxayhgvdkiqnc5cm4l5h04ffcb9a3";
+    rev = "75d74f53a34c875285a665d8878e5b363edfbea5";
+  };
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring bytestring-trie directory filepath ghc-prim time
+    transformers
+  ];
+  executableHaskellDepends = [ base directory filepath time ];
+  testHaskellDepends = [ base bytestring transformers ];
+  homepage = "https://github.com/acowley/hpp";
+  description = "A Haskell pre-processor";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
This lets us build the Eta and start a shell. Trying to run `eta-build install` gives this:

```
$ eta-build install
# eta (for install)
# git (for install)# eta-pkg (for install)
# etlas (for install)
Downloading the latest package lists from:
- hackage.haskell.org
- git@github.com/typelead/etlas-index
Updating binary package index.
Verification loop. Errors in order:
  Version of <repo>/timestamp.json is less than the previous version
  Version of <repo>/timestamp.json is less than the previous version
  Version of <repo>/timestamp.json is less than the previous version
  Version of <repo>/timestamp.json is less than the previous version
  Version of <repo>/timestamp.json is less than the previous version
Error when running Shake build system:
* install
user error (Development.Shake.cmd, system command failed
Command: etlas update
Exit code: 1
Stderr:
Verification loop. Errors in order:
  Version of <repo>/timestamp.json is less than the previous version
  Version of <repo>/timestamp.json is less than the previous version
  Version of <repo>/timestamp.json is less than the previous version
  Version of <repo>/timestamp.json is less than the previous version
  Version of <repo>/timestamp.json is less than the previous version
)
```