### PR TITLE
 Support for cabal new-build in a nix-shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ release.log
 binaries/
 .gradle
 testing
+/dist-newstyle/

--- a/cabal.nix.project
+++ b/cabal.nix.project
@@ -1,0 +1,20 @@
+-- Start nix-shell with all of the tools needed for building:
+--
+--   nix-shell -A shells.ghc
+--
+-- Inside that shell build the project using cabal new-build:
+--
+--   cabal --project-file=cabal.nix.project new-build
+
+packages:
+  ./
+  codec-jvm/
+  libraries/eta-boot/
+  libraries/eta-boot-meta/
+  libraries/eta-meta/
+  libraries/eta-repl/
+  utils/eta-pkg/
+  etlas/etlas/
+  etlas/etlas-cabal/
+  etlas/hackage-security/hackage-security/
+  shake/

--- a/default.nix
+++ b/default.nix
@@ -46,4 +46,22 @@ hpkgs // {
       glibcLocales
     ];
   } "";
+
+  shells = {
+    ghc = hpkgs.shellFor {
+      packages = p: [
+        p.eta
+        p.codec-jvm
+        p.eta-boot
+        p.eta-boot-meta
+        p.eta-meta
+        p.eta-repl
+        p.eta-pkg
+        p.etlas
+        p.etlas-cabal
+        p.hackage-security
+        p.shake
+        ];
+    };
+  };
 }

--- a/libraries/eta-meta/Language/Eta/Meta/Ppr.hs
+++ b/libraries/eta-meta/Language/Eta/Meta/Ppr.hs
@@ -15,7 +15,7 @@ import Data.Char ( toLower, chr, ord, isSymbol )
 import GHC.Show  ( showMultiLineString )
 import Data.Ratio ( numerator, denominator )
 
-#if MIN_VERSION_base(4,10,0)
+#if MIN_VERSION_base(4,11,0)
 import Prelude hiding ((<>))
 #endif
 

--- a/libraries/eta-meta/Language/Eta/Meta/PprLib.hs
+++ b/libraries/eta-meta/Language/Eta/Meta/PprLib.hs
@@ -44,7 +44,7 @@ import qualified Language.Eta.Meta.Lib.Map as Map ( lookup, insert, empty )
 #if __GLASGOW_HASKELL__ < 709
 import Control.Applicative( Applicative(..) )
 #endif
-#if MIN_VERSION_base(4,10,0)
+#if MIN_VERSION_base(4,11,0)
 import Prelude hiding ((<>))
 #endif
 


### PR DESCRIPTION
I find this is a sort of "best of both worlds" way of working.

I set it up as `nix-shell -A shells.ghc` because this is what the reflex-platform uses [here](https://github.com/reflex-frp/reflex-platform/blob/develop/docs/project-development.md).  Reflex platform also has `nix-shell -A shells.ghcjs` for compiling with ghcjs.

I've added [nix support to Leksah](https://github.com/leksah/leksah#leksah-an-integrated-development-environment-for-haskell) that uses `shells.ghc` and `shells.ghcjs`.  I am keen to add `shells.eta` too.