### PR TITLE
Fix Nix build, compile flags

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,14 +17,6 @@ let
       src = rewriteRelative eta-nix args.src;
     });
 
-    etlas = haskell.lib.overrideCabal super.etlas (drv: {
-      # Nix should only compile Setup.hs with setup-depends, but it doesn't:
-      # https://github.com/NixOS/nixpkgs/issues/24809
-      preCompileBuildDriver = ''
-        ${drv.preCompileBuildDriver or ""}
-        setupCompileFlags+=" -hide-package=etlas-cabal"
-      '';
-    });
     eta = haskell.lib.overrideCabal super.eta (drv: {
       # Makes the build a bit faster
       src = onlyFiles ["compiler" "include" "eta" "eta.cabal" "LICENSE" "tests"] drv.src;


### PR DESCRIPTION
Fixes #827 

Once these build flags are gone, I can successfully get into the `eta-build-shell` with Nix (and install/uninstall).