### PR TITLE
change FiberYieldException code in capability

### DIFF
--- a/rts/src/main/java/eta/runtime/stg/Capability.java
+++ b/rts/src/main/java/eta/runtime/stg/Capability.java
@@ -183,6 +183,7 @@ public final class Capability implements LocalHeap {
                         result = t.closure.enter(context);
                     } catch (FiberYieldException fye) {
                         result = null;
+                        t.closure = Closures.evalLazyIO(t.closure);
                     } catch (java.lang.Exception e) {
                         t.whatNext = ThreadKilled;
                         pendingException = (java.lang.Exception) Exception.normalize(e);


### PR DESCRIPTION
This change in the handling of `FiberYieldException` is needed for implementing exception handling in Fiber.
This will break the previous implementation of `yiledFiber`, so `eta-fibers-dev` would also need to be updated.