### PR TITLE
fix INSTALL_DIR in cleaninstall.sh

### DIFF
--- a/cci.sh
+++ b/cci.sh
@@ -5,7 +5,7 @@ set -e
 INSTALL_DIR="$1"
 if [ \( -z "$INSTALL_DIR" \) -o \( "-" = "$INSTALL_DIR" \) ]
 then
-    INSTALL_DIR=`stack path --local-bin > /dev/null 2>&1 || echo "" > /dev/null`
+    INSTALL_DIR=`stack path --local-bin 2> /dev/null || echo ""`
     if [ -z "$INSTALL_DIR" ]
     then
         INSTALL_DIR=`stack path --local-bin-path`

--- a/cleaninstall.sh
+++ b/cleaninstall.sh
@@ -5,7 +5,7 @@ set -e
 INSTALL_DIR="$1"
 if [ \( -z "$INSTALL_DIR" \) -o \( "-" = "$INSTALL_DIR" \) ]
 then
-    INSTALL_DIR=`stack path --local-bin > /dev/null 2>&1 || echo "" > /dev/null`
+    INSTALL_DIR=`stack path --local-bin 2> /dev/null || echo ""`
     if [ -z "$INSTALL_DIR" ]
     then
         INSTALL_DIR=`stack path --local-bin-path`


### PR DESCRIPTION
## Description

The script appears to not be written as intended.

`stack path --local-bin` outputs to stdout, but it is then redirected to /dev/null. Therefore, as it is currently written, `stack path --local-bin-path` will always be used.

Same for `echo "" > /dev/null`

## How Has This Been Tested?

On my laptop.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [ ] Test suite change

## Checklist:
- [x] I have read the **CONTRIBUTING** document.