### PR TITLE
loopification

### DIFF
--- a/compiler/Eta/Main/DynFlags.hs
+++ b/compiler/Eta/Main/DynFlags.hs
@@ -3512,7 +3512,7 @@ optLevelFlags -- see Note [Documenting optimisation flags]
     , ([1,2],   Opt_FloatIn)
     , ([1,2],   Opt_FullLaziness)
     , ([1,2],   Opt_IgnoreAsserts)
-    , ([1,2],   Opt_Loopification)
+    , ([0,1,2], Opt_Loopification) -- always to avoid SOE on JVM (#866)
     , ([1,2],   Opt_Specialise)
     , ([1,2],   Opt_Strictness)
     , ([1,2],   Opt_UnboxSmallStrictFields)

--- a/compiler/Eta/Prelude/PrimOp.hs
+++ b/compiler/Eta/Prelude/PrimOp.hs
@@ -4877,6 +4877,13 @@ primOpHasSideEffects WriteJFloatArrayOp   = True
 primOpHasSideEffects NewJDoubleArrayOp    = True
 primOpHasSideEffects ReadJDoubleArrayOp   = True
 primOpHasSideEffects WriteJDoubleArrayOp  = True
+-- Start
+-- These don't technically do any side effects since they either return one of the args, or
+-- a new Object, but will be treated as such to avoid speculation in the optimizer.
+primOpHasSideEffects FreshStateTokenOp    = True
+primOpHasSideEffects FreshObjectTokenOp     = True
+primOpHasSideEffects FreshNullObjectTokenOp = True
+-- End
 primOpHasSideEffects _ = False
 
 primOpCanFail :: PrimOp -> Bool

--- a/compiler/Eta/StrAnal/DmdAnal.hs
+++ b/compiler/Eta/StrAnal/DmdAnal.hs
@@ -32,7 +32,7 @@ import Eta.Types.FamInstEnv
 import Eta.Utils.Util
 import Eta.Utils.Maybes    ( isJust )
 import Eta.Prelude.TysWiredIn
-import Eta.Prelude.TysPrim ( realWorldStatePrimTy )
+import Eta.Prelude.TysPrim ( realWorldStatePrimTy, jobjectPrimTyCon )
 import Eta.Main.ErrUtils   ( dumpIfSet_dyn )
 import Eta.BasicTypes.Name ( getName, stableNameCmp )
 import Data.Function       ( on )
@@ -343,7 +343,9 @@ io_hack_reqd :: CoreExpr -> DataCon -> [Var] -> Bool
 io_hack_reqd scrut con bndrs
   | (bndr:_) <- bndrs
   , con == tupleCon UnboxedTuple 2
-  , idType bndr `eqType` realWorldStatePrimTy
+  , let bndrType = idType bndr
+  , bndrType `eqType` realWorldStatePrimTy ||
+    maybe False (\(tc,_) -> tc == jobjectPrimTyCon) (splitTyConApp_maybe bndrType)
   , (fun, _) <- collectArgs scrut
   = case fun of
       Var f -> not (isPrimOpId f)

--- a/eta-serv/eta-serv.cabal
+++ b/eta-serv/eta-serv.cabal
@@ -1,7 +1,7 @@
 name:                eta-serv
 -- @VERSION_CHANGE@
 -- @BUILD_NUMBER@
-version:             0.8.6.2
+version:             0.8.6.3
 license:             BSD3
 license-file:        LICENSE
 maintainer:          typeleadhq@gmail.com

--- a/eta.cabal
+++ b/eta.cabal
@@ -1,7 +1,7 @@
 name:                eta
 -- @VERSION_CHANGE@
 -- @BUILD_NUMBER@
-version:             0.8.6.2
+version:             0.8.6.3
 description:         Modern Haskell on the JVM
 license:             BSD3
 license-file:        LICENSE

--- a/eta/Main.hs
+++ b/eta/Main.hs
@@ -96,8 +96,7 @@ main = do
             -- start our GHC session
             GHC.runGhc opt_TopDir $ do
 
-              -- -floopification should *always* be on (#866)
-              dflags <- flip gopt_set Opt_Loopification <$> GHC.getSessionDynFlags
+              dflags <- GHC.getSessionDynFlags
 
               case postStartupMode of
                   Left preLoadMode ->

--- a/libraries/eta-meta/eta-meta.cabal
+++ b/libraries/eta-meta/eta-meta.cabal
@@ -1,5 +1,5 @@
 name:           eta-meta
-version:        0.8.6.2
+version:        0.8.6.3
 license:        BSD3
 license-file:   LICENSE
 category:       Metaprogamming

--- a/libraries/eta-repl/eta-repl.cabal
+++ b/libraries/eta-repl/eta-repl.cabal
@@ -1,7 +1,7 @@
 name:           eta-repl
 -- @VERSION_CHANGE@
 -- @BUILD_NUMBER@
-version:        0.8.6.2
+version:        0.8.6.3
 license:        BSD3
 license-file:   LICENSE
 category:       Eta Tools

--- a/rts/src/main/java/eta/runtime/exception/RuntimeInternalError.java
+++ b/rts/src/main/java/eta/runtime/exception/RuntimeInternalError.java
@@ -3,9 +3,6 @@ package eta.runtime.exception;
 public class RuntimeInternalError extends Error {
 
     public RuntimeInternalError(String message) {
-        // @VERSION_CHANGE@
-        // @BUILD_NUMBER@
-        // @BUILD_NUMBER_INTERNAL@
-        super("\n[Eta v0.8.6b2] " + message + "\nPlease report this as a bug: https://github.com/typelead/eta/issues");
+        super("\n[Eta Panic] " + message + "\nPlease report this as a bug: https://github.com/typelead/eta/issues");
     }
 }

--- a/tests/suite/Driver.hs
+++ b/tests/suite/Driver.hs
@@ -291,7 +291,7 @@ goldenVsFileDiff' name cmdf ref new act =
    upd _ = BS.readFile new >>= BS.writeFile ref
 
 ignored :: Set String
-ignored = S.fromList ["Echo", "FullExportTest", "tc141", "tc168", "tc211",
+ignored = S.fromList ["Echo", "tc141", "tc168", "tc211",
         "T14163", "T4912", "T6018", "T7541", "InstanceMethod", "TcTypeNatSimple",
         "TcTypeSymbolSimple", "tcfail150", "tcfail205", "annrun01", "TH_overloadedlabels"]
 

--- a/tests/suite/ffi/run/FullExportTest.stdout
+++ b/tests/suite/ffi/run/FullExportTest.stdout
@@ -1,1 +1,8 @@
-ExitFailure 1Error: Could not find or load main class eta.main
+89
+89
+144
+144
+233
+233
+377
+377

--- a/utils/eta-pkg/eta-pkg.cabal
+++ b/utils/eta-pkg/eta-pkg.cabal
@@ -2,7 +2,7 @@ name: eta-pkg
 -- @VERSION_CHANGE@
 -- @BUILD_NUMBER@
 -- @BUILD_NUMBER_INTERNAL@
-version: 0.8.6.2
+version: 0.8.6.3
 copyright: XXX
 license: BSD3
 -- XXX License-File: LICENSE


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This addresses #866 by adding the "-floopification" flag to eta by default. Users can still turn off the optimization through CLI arguments, config, sandbox settings, or cabal file (there is another patch on etlas related to this that insures etlas calls to eta do not turn off the flag by default).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Ran the available test harness and additional tests (yet to be submitted --- working on improving the test harness as in #865 and related to #847) to verify that the loopification optimization is applied by default in both eta and etlas.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [ ] Test suite change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] I have read the **CONTRIBUTING** document.
