### PR TITLE
'stack path --local-bin-path' will be deprecated

### DIFF
--- a/cleaninstall.cmd
+++ b/cleaninstall.cmd
@@ -3,7 +3,7 @@ set INSTALL_DIR=%~1
 if not defined INSTALL_DIR (
   (for /f "delims=" %%a in ('stack path --local-bin') do @set INSTALL_DIR=%%a) 2> nul
   if not defined INSTALL_DIR (
-    for /f "delims=" %%a in ('stack path --local-bin-path') do @set INSTALL_DIR=%%a
+    for /f "delims=" %%a in ('stack path --local-bin') do @set INSTALL_DIR=%%a
   )
 )
 shift

--- a/cleaninstall.sh
+++ b/cleaninstall.sh
@@ -8,7 +8,7 @@ then
     INSTALL_DIR=`stack path --local-bin 2> /dev/null || echo ""`
     if [ -z "$INSTALL_DIR" ]
     then
-        INSTALL_DIR=`stack path --local-bin-path`
+        INSTALL_DIR=`stack path --local-bin`
     fi
 fi
 


### PR DESCRIPTION
## Description
This creates an (unnecessary/irritating) warning during install.

## How Has This Been Tested?
Locally on my machine (.sh only).

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [ ] Test suite change

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
