### PR TITLE
Update Nix code

### DIFF
--- a/docs/0-user-guides/0-eta-user-guide/1-installation/5-nix.md
+++ b/docs/0-user-guides/0-eta-user-guide/1-installation/5-nix.md
@@ -8,19 +8,18 @@ Make sure you have the following tools installed on your system:
 
 ## Installation
 
-To obtain an environment with `eta` and `etlas`, run the following commands:
+Install the Nix overlay:
 
 ```sh
-$ git clone --recursive --depth 1 https://github.com/typelead/eta
-$ cd eta
-$ nix-shell -A eta-build-shell
+$ git clone https://github.com/eta-lang/eta-nix.git
+$ mkdir -p ~/.config/nixpkgs/overlays
+$ ln -s $PWD/eta-nix/overlay.nix ~/.config/nixpkgs/overlays/eta-overlay.nix
 ```
 
-Once in the shell, run the following commands:
+To obtain an environment with `eta` and the `lens` package available:
 
 ```sh
-$ eta-build uninstall
-$ eta-build install
+$ nix-shell -p 'etaPackages.etaWithPackages (p: [ p.lens ])'
 ```
 
 ## Jump to Module


### PR DESCRIPTION
Now provides an etaPackages attribute, which allows compiling any Hackage
package with the cloned version of Eta.

Problems:

* Caching is a bit problematic, changing any file will probably rebuild
  everything
* Etlas under the nix-shell doesn't work because although we have all the
  dependencies, they're not located by Etlas

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [ ] Test suite change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
