### PR TITLE
Allow type variables in ffi export result type

### DIFF
--- a/compiler/Eta/TypeCheck/TcType.hs
+++ b/compiler/Eta/TypeCheck/TcType.hs
@@ -1649,12 +1649,15 @@ isFFIExternalTy vs ty
   | otherwise = checkRepTyCon legalFEArgTyCon ty empty
 
 isFFIImportResultTy :: DynFlags -> Type -> Validity
-isFFIImportResultTy dflags ty
-  | isTyVarTy ty = IsValid
-  | otherwise = checkRepTyCon (legalFIResultTyCon dflags) ty empty
+isFFIImportResultTy dflags = isFFIResultTy (legalFIResultTyCon dflags) 
 
 isFFIExportResultTy :: Type -> Validity
-isFFIExportResultTy ty = checkRepTyCon legalFEResultTyCon ty empty
+isFFIExportResultTy = isFFIResultTy legalFEResultTyCon
+
+isFFIResultTy :: (TyCon -> Type -> Bool) -> Type -> Validity
+isFFIResultTy isLegalResultTyCon ty
+  | isTyVarTy ty = IsValid
+  | otherwise = checkRepTyCon isLegalResultTyCon ty empty
 
 -- isFFIDynTy :: Type -> Type -> Validity
 -- -- The type in a foreign import dynamic must be Ptr, FunPtr, or a newtype of

--- a/rts/src/main/java/eta/runtime/apply/FunctionId.java
+++ b/rts/src/main/java/eta/runtime/apply/FunctionId.java
@@ -1,0 +1,21 @@
+package eta.runtime.apply;
+
+import eta.runtime.stg.Closure;
+import eta.runtime.stg.Stg;
+import eta.runtime.stg.StgContext;
+
+public class FunctionId extends Function1 {
+    public static FunctionId INSTANCE = new FunctionId();
+    
+    public final Closure apply1(StgContext paramStgContext, Closure paramClosure) {
+        if (paramStgContext.trampoline)
+            Stg.apply1Tail(paramStgContext, this, paramClosure);
+        return paramClosure.evaluate(paramStgContext);
+    }
+    
+    public final Closure enter(StgContext paramStgContext) {
+        if (paramStgContext.trampoline)
+            Stg.enterTail(paramStgContext, this);
+        return paramStgContext.R1.evaluate(paramStgContext);
+    }
+}

--- a/rts/src/main/java/eta/runtime/stg/Closures.java
+++ b/rts/src/main/java/eta/runtime/stg/Closures.java
@@ -3,6 +3,7 @@ package eta.runtime.stg;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
+import eta.runtime.apply.FunctionId;
 import eta.runtime.thunk.ApO;
 import eta.runtime.thunk.Ap1Upd;
 import eta.runtime.thunk.Ap2Upd;
@@ -36,12 +37,14 @@ public class Closures {
     public static Closure runFinalizerBatch;
     public static Closure $fExceptionJException;
     public static Closure showException;
-
+    public static Closure trivialExtendsInstance;
+    public static Closure $fClass_Object;
     /* Standard Constructors */
     public static Constructor Int = null;
     public static Constructor JException = null;
     public static Constructor SomeException = null;
-
+    public static Constructor DZCExtends = null;
+    
     /* Classes */
     public static Class<?> ZC;
     public static Class<?> ZMZN;
@@ -68,12 +71,19 @@ public class Closures {
             SomeException     = loadDataCon("base.ghc.Exception", "SomeException", Closure.class, Closure.class);
             $fExceptionJException = loadClosure("base.java.Exception", "$fException_JException");
             showException         = loadClosure("base.java.Exception", "showException");
+            $fClass_Object    = loadClosure("ghc_prim.ghc.Classes", "$fClass_Object");
+            DZCExtends        = loadDataCon("ghc_prim.ghc.classes","DZCExtends",
+                                            Closure.class, Closure.class,
+                                            Closure.class, Closure.class);
+            trivialExtendsInstance = loadTrivialExtendsInstance($fClass_Object);
+            
             ZC   = Class.forName("ghc_prim.ghc.types.datacons.ZC");
             ZMZN = Class.forName("ghc_prim.ghc.types.datacons.ZMZN");
             Czh  = Class.forName("ghc_prim.ghc.types.datacons.Czh");
             Izh  = Class.forName("ghc_prim.ghc.types.datacons.Izh");
             Szh  = Class.forName("integer.ghc.integer.type.datacons.Szh");
             Jzh  = Class.forName("integer.ghc.integer.type.datacons.Jzh");
+
         } catch (Exception e) {
             System.err.println("FATAL ERROR: Failed to load base closures.");
             e.printStackTrace();
@@ -94,7 +104,17 @@ public class Closures {
         return Class.forName(className.toLowerCase() + ".datacons." + dataConName).getConstructor(types);
     }
 
+    public static Closure loadTrivialExtendsInstance(Closure $fClass_Object)
+        throws InstantiationException, IllegalAccessException, InvocationTargetException
+    {
+        return (Closure) DZCExtends.newInstance($fClass_Object, $fClass_Object,
+                                                FunctionId.INSTANCE, FunctionId.INSTANCE);
+    }
 
+    public static Closure getTrivialExtendsInstance()
+    {
+        return trivialExtendsInstance;
+    }
     /* Closures for Main Evaluation */
 
     public static Closure evalLazyIO(Closure p) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
I assimilate check for result type between imports and exports
## How Has This Been Tested?
Compiling a project with the ffi export to be allowed: https://github.com/jneira/eta-test/blob/print-ffi/src/Foreign.hs 

## Types of changes
- [X] Bug fix (non-breaking change which fixes partially the issue #892)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
