### PR TITLE
Tweak trampoline function to accept DataCon closures

### DIFF
--- a/rts/src/main/java/eta/runtime/stg/Stg.java
+++ b/rts/src/main/java/eta/runtime/stg/Stg.java
@@ -82,7 +82,7 @@ public class Stg {
         if (!(closure instanceof Thunk) && !(closure instanceof DataCon)) {
             final Class<?> clazz = closure.getClass();
             throw new IllegalStateException
-                ("The trampoline function expects a thunk and not a function ["
+                ("The trampoline function expects a thunk or data constructor and not a function ["
                  + clazz + " extends "
                  + clazz.getSuperclass() + "]");
         }

--- a/rts/src/main/java/eta/runtime/stg/Stg.java
+++ b/rts/src/main/java/eta/runtime/stg/Stg.java
@@ -79,7 +79,7 @@ public class Stg {
         };
 
     public static Closure trampoline(final StgContext context, final Closure closure) {
-        if (!(closure instanceof Thunk)) {
+        if (!(closure instanceof Thunk) && !(closure instanceof DataCon)) {
             final Class<?> clazz = closure.getClass();
             throw new IllegalStateException
                 ("The trampoline function expects a thunk and not a function ["


### PR DESCRIPTION
This fixes a problem with lens-aeson support (eta-hackage #120)

## Description
Ensure the trampoline function permits DataCons as well as Thunks. This seems to permit lens libraries such as lens-aeson to function properly.

## How Has This Been Tested?
./runtests.sh is passing all tests except arr003, which was failing before this change. I also reproduced the issue in eta-hackage (#120) and verified that this change resolved it.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [ ] Test suite change

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
