### PR TITLE
Add WORDS_BIGENDIAN

### DIFF
--- a/libraries/rts/MachDeps.h
+++ b/libraries/rts/MachDeps.h
@@ -84,4 +84,7 @@
 #define SIZEOF_HSSTABLEPTR      SIZEOF_INT
 #define ALIGNMENT_HSSTABLEPTR   ALIGNMENT_INT
 
+/* The JVM uses big-endian. */
+#define WORDS_BIGENDIAN
+
 #endif /* MACHDEPS_H */


### PR DESCRIPTION
This Signals to to other libraries that big-endiannes is used.
Resolves issue #899.
