### PR TITLE
Minor correction to Object Array example, added Java Array example...

### DIFF
--- a/docs/0-user-guides/0-eta-user-guide/3-java-interop/3-arrays.md
+++ b/docs/0-user-guides/0-eta-user-guide/3-java-interop/3-arrays.md
@@ -48,20 +48,38 @@ The following table lists the exported types and their element types.
 | `float[]`     |   `JFloatArray`    |      `Float` |
 | `double[]`    |   `JDoubleArray`   |     `Double` |
 
+### Example of use with a JByteArray
+
+```eta
+import Java
+
+main :: IO ()
+main = java $ do
+  arr <- arrayFromList integers :: Java a JByteArray
+  elems <- withObject arr $ mapM aget [0..9]
+  io $ print elems
+  withObject arr $ mapM_ (\i -> aset i (fromIntegral i * 2)) [0..9]
+  arrList <- arr <.> arrayToList
+  io $ print arrList
+  where integers = [1..10] :: [Byte]
+```
+
+Outputs:  
+[1,2,3,4,5,6,7,8,9,10]  
+[0,2,4,6,8,10,12,14,16,18]
+
 ## Object Arrays
 
 Object arrays must be explicitly declared as JWTs and must have an instance of the JArray typeclass defined for them.
 
 The `Java.Array` has one pre-defined object array: `JStringArray` which corresponds to `String[]` in Java and has `JString` as the element type.
 
-
-
 ### Example
 
 ```eta
 {-# LANGUAGE MultiParamTypeClasses #-}
 
-import Java
+import Java hiding (JInteger)
 
 data JInteger = JInteger @java.lang.Integer
   deriving (Class, Show)
@@ -88,5 +106,10 @@ main = java $ do
   
 ```
 
+Outputs:  
+[JInteger 1,JInteger 2,JInteger 3,JInteger 4,JInteger 5,JInteger 6,JInteger 7,JInteger 8,JInteger 9,JInteger 10]  
+[JInteger 0,JInteger 2,JInteger 4,JInteger 6,JInteger 8,JInteger 10,JInteger 12,JInteger 14,JInteger 16,JInteger 18]
+
 ## Next Section
+
 We will now proceed with handling Java Subclasses.


### PR DESCRIPTION
## Description
As per issues  #929, the `import` line for the Object :Array example was corrected to hide the existing definition for JInteger so the example compiles without errors.

As well, as per issue #930 a similar example for the use of Java Arrays (JByteArray in this case) was added.

The expected output was added to both examples.

## How Has This Been Tested?
Only changes the documentation, but the changed/added examples were tested with "etlas run" using etlas version 1.5.0.0 and eta version 0.8.6b4.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x ] Documentation change
- [ ] Test suite change

## Checklist:
- [x ] I have read the **CONTRIBUTING** document.