### PR TITLE
Add an example showing FFI of a static method with no parameters...

### DIFF
--- a/docs/0-user-guides/0-eta-user-guide/3-java-interop/2-java-ffi.md
+++ b/docs/0-user-guides/0-eta-user-guide/3-java-interop/2-java-ffi.md
@@ -86,6 +86,20 @@ foreign import java unsafe "@static java.io.File.createTempFile"
   createTempFile2 :: String -> String -> File
 ```
 
+### Example importing a static method with no arguments (use the same type of signature for instance methods with no parameters)
+
+``` eta
+import Java
+
+foreign import java unsafe "@static java.lang.System.currentTimeMillis"
+  currentTimeMillis :: IO Int64
+  
+main :: IO ()
+main = do
+  now <- currentTimeMillis
+  print now
+```
+
 ## Importing Constructors
 
 Let’s import the `File(String)` [constructor](https://docs.oracle.com/javase/7/docs/api/java/io/File.html#File(java.lang.String)) from the [java.io.File](https://docs.oracle.com/javase/7/docs/api/java/io/File.html) class.


### PR DESCRIPTION
## Description
As per issue #931, the type signature to use when importing a method (static or instance) with no parameters was formerly not formally documents;  This PR provides an example of how to do it.

## How Has This Been Tested?
The documentation example was successfully run on the online IDE of the Eta Tour.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation change
- [ ] Test suite change

## Checklist:
- [ x] I have read the **CONTRIBUTING** document.