### PR TITLE
Fix path used for temp file creation

### DIFF
--- a/libraries/base/System/IO.hs
+++ b/libraries/base/System/IO.hs
@@ -514,8 +514,8 @@ openTempFile' loc tmp_dir template binary mode = findTempName
         combine a b
                   | null b = a
                   | null a = b
-                  | last a == pathSeparator = a ++ b
-                  | otherwise = a ++ [pathSeparator] ++ b
+                  | last a == dirSeparator = a ++ b
+                  | otherwise = a ++ [dirSeparator] ++ b
 
 -- int rand(void) from <stdlib.h>, limited by RAND_MAX (small value, 32768)
 foreign import java unsafe "@static eta.base.Utils.c_rand"
@@ -541,11 +541,11 @@ openNewFile filepath binary mode = do
   fd <- c_open f oflags mode
   return (NewFileCreated (superCast fd))
 
-foreign import java "@static @field eta.base.Utils.pathSeparatorChar"
-  pathSeparator' :: Int
+foreign import java "@static @field eta.base.Utils.dirSeparatorChar"
+  dirSeparator' :: Int
 
-pathSeparator :: Char
-pathSeparator = unsafeChr pathSeparator'
+dirSeparator :: Char
+dirSeparator = unsafeChr dirSeparator'
 
 -- $locking
 -- Implementations should enforce as far as possible, at least locally to the

--- a/libraries/base/java-utils/Utils.java
+++ b/libraries/base/java-utils/Utils.java
@@ -632,7 +632,7 @@ public class Utils {
         return FileChannel.open(fChan.toPath(), fOpts);
     }
 
-    public static final int pathSeparatorChar = File.pathSeparatorChar;
+    public static final int dirSeparatorChar = File.separatorChar;
 
     public static void puts(String msg) {
         System.out.println(msg);


### PR DESCRIPTION
File.pathSeparatorChar is the separator for PATH and similar
variables. File.separatorChar is the correct separator for
directories.

## Description

The temp file code was using `:` as the path separator instead of `/`, leading to paths like `/tmp:criterion425512593.json`.

## How Has This Been Tested?

Running a criterion benchmark yielded

```
Exception in thread "main" java.nio.file.AccessDeniedException: /tmp:criterion425512593.json
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
        at java.base/sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:178)
        at java.base/java.nio.channels.FileChannel.open(FileChannel.java:292)
        at eta.base.Utils.fileChannelOpen(Utils.java:600)
        at base.system.posix.Internals$c_open1.call(Internals.hs:344)
        at base.system.IO$$wa.call(IO.hs:500)
        at criterion.criterion.Internal$$wa6.call(Internal.hs:125)
        at criterion.criterion.Main$defaultMain3.call(Main.hs:173)
        at criterion.criterion.Main$defaultMain2.call(Main.hs:152)
        at main.Main$main1.call(Main.hs:20)
        at main.Main$main1.applyV(Main.hs)
        at eta.runtime.exception.Exception.catch_(Exception.java:129)
        at main.Main$main20.call(Main.hs)
        at main.Main$DZCmain.call(Main.hs:20)
        at main.Main$DZCmain.applyV(Main.hs:20)
        at eta.runtime.stg.Closures$EvalLazyIO.enter(Closures.java:152)
        at eta.runtime.stg.Capability.schedule(Capability.java:246)
        at eta.runtime.stg.Capability.scheduleClosure(Capability.java:202)
        at eta.runtime.Runtime.evalLazyIO(Runtime.java:392)
        at eta.runtime.Runtime.main(Runtime.java:385)
        at eta.main.main(Unknown Source)
```

After this fix, the criterion benchmark doesn't work (hangs), but at least it doesn't immediately throw this error.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [ ] Test suite change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
