### PR TITLE
Add support for java-sources in eta repl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ binaries/
 .gradle
 testing
 /dist-newstyle/
+.vscode/

--- a/compiler/Eta/Main/DriverPhases.hs
+++ b/compiler/Eta/Main/DriverPhases.hs
@@ -48,8 +48,8 @@ import Eta.Utils.Outputable
 import Eta.Utils.Platform
 import System.FilePath
 import Eta.Utils.Binary
-import Eta.Utils.Utils (looksLikeModuleName)
-
+import Eta.Utils.Util (looksLikeModuleName)
+import Data.List (partition)
 -----------------------------------------------------------------------------
 -- Phases
 
@@ -345,8 +345,8 @@ isObjectFilename, isDynLibFilename :: Platform -> FilePath -> Bool
 isObjectFilename platform f = isObjectSuffix platform (drop 1 $ takeExtension f)
 isDynLibFilename platform f = isDynLibSuffix platform (drop 1 $ takeExtension f)
 
-partitionByHaskellish :: [(Filepath,Maybe Phase)]
-                      -> ([(Filepath,Maybe Phase)],[(Filepath,Maybe Phase)])
+partitionByHaskellish :: [(FilePath,Maybe Phase)]
+                      -> ([(FilePath,Maybe Phase)],[(FilePath,Maybe Phase)])
 partitionByHaskellish srcs = partition haskellish srcs
   where haskellish (f,Nothing) =
           looksLikeModuleName f || isHaskellUserSrcFilename f || '.' `notElem` f

--- a/compiler/Eta/Main/DriverPhases.hs
+++ b/compiler/Eta/Main/DriverPhases.hs
@@ -36,7 +36,9 @@ module Eta.Main.DriverPhases (
    isJavaClassishFilename,
    isDynLibFilename,
    isHaskellUserSrcFilename,
-   isSourceFilename
+   isSourceFilename,
+
+   partitionByHaskellish
  ) where
 
 #include "HsVersions.h"
@@ -46,6 +48,7 @@ import Eta.Utils.Outputable
 import Eta.Utils.Platform
 import System.FilePath
 import Eta.Utils.Binary
+import Eta.Utils.Utils (looksLikeModuleName)
 
 -----------------------------------------------------------------------------
 -- Phases
@@ -341,3 +344,11 @@ isHaskellSigFilename     f = isHaskellSigSuffix     (drop 1 $ takeExtension f)
 isObjectFilename, isDynLibFilename :: Platform -> FilePath -> Bool
 isObjectFilename platform f = isObjectSuffix platform (drop 1 $ takeExtension f)
 isDynLibFilename platform f = isDynLibSuffix platform (drop 1 $ takeExtension f)
+
+partitionByHaskellish :: [(Filepath,Maybe Phase)]
+                      -> ([(Filepath,Maybe Phase)],[(Filepath,Maybe Phase)])
+partitionByHaskellish srcs = partition haskellish srcs
+  where haskellish (f,Nothing) =
+          looksLikeModuleName f || isHaskellUserSrcFilename f || '.' `notElem` f
+        haskellish (_,Just phase) =
+          phase `notElem` [ As True, As False, Cc, Cobjc, Cobjcpp, CmmCpp, Cmm, StopLn ]

--- a/eta/Eta/REPL/UI.hs
+++ b/eta/Eta/REPL/UI.hs
@@ -1741,6 +1741,11 @@ loadModule' files = do
   -- Grab references to the currently loaded modules so that we can
   -- see if they leak.
   let !dflags = hsc_dflags hsc_env
+
+  liftIO $ debugTraceMsg dflags 3 $ 
+    text (   "loadModule': haskellFiles=" ++ (show haskellFiles) 
+          ++ ", otherFiles=" ++ (show otherFiles))
+
   leak_indicators <- if gopt Opt_EtaReplLeakCheck dflags
     then liftIO $ getLeakIndicators hsc_env
     else return (panic "no leak indicators")
@@ -1750,6 +1755,7 @@ loadModule' files = do
   lift discardActiveBreakPoints
 
   let dflags' = foldr addJarInputs dflags (map fst otherFiles)
+  
   _ <- GHC.setSessionDynFlags dflags'
   
   GHC.setTargets []

--- a/eta/Eta/REPL/UI.hs
+++ b/eta/Eta/REPL/UI.hs
@@ -1744,7 +1744,7 @@ loadModule' files = do
 
   liftIO $ debugTraceMsg dflags 3 $ 
     text (   "loadModule': haskellFiles=" ++ (show haskellFiles) 
-          ++ ", otherFiles=" ++ (show otherFiles))
+         ++ ", otherFiles=" ++ (show otherFiles))
 
   leak_indicators <- if gopt Opt_EtaReplLeakCheck dflags
     then liftIO $ getLeakIndicators hsc_env
@@ -1754,7 +1754,8 @@ loadModule' files = do
   _ <- GHC.abandonAll
   lift discardActiveBreakPoints
 
-  let dflags' = foldr addJarInputs dflags (map fst otherFiles)
+  objectFiles <- liftIO $ compileFiles hsc_env StopLn otherFiles
+  let dflags' = foldr addJarInputs dflags (map fst objectFiles)
   
   _ <- GHC.setSessionDynFlags dflags'
   

--- a/eta/Main.hs
+++ b/eta/Main.hs
@@ -644,11 +644,7 @@ doMake srcs  = do
     ok_flag <- GHC.load LoadAllTargets
     when (failed ok_flag) (liftIO $ exitWith (ExitFailure 1))
     return ()
-  where (hs_srcs, non_hs_srcs) = partition haskellish srcs
-        haskellish (f,Nothing) =
-          looksLikeModuleName f || isHaskellUserSrcFilename f || '.' `notElem` f
-        haskellish (_,Just phase) =
-          phase `notElem` [ As True, As False, Cc, Cobjc, Cobjcpp, CmmCpp, Cmm, StopLn ]
+  where (hs_srcs, non_hs_srcs) = partitionByHaskellish srcs
 
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With those changes now it is possible to compile and load javaish targets (.java. class. jar)
It works at repl startup and with :load (i.e. you can do `:load path/to/my.(java|class|jar)` on the fly)
## Description
<!--- Describe your changes in detail -->
Main changes are in `Eta.REPL.UI` module where it is the calling code to `Eta.Main.DriverPipeline` to compile files and `Eta.REPL.Linker` to add them to repl classpath.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Manually firing repls with different java source files
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue). Fixes #805
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change
- [ ] Test suite change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
